### PR TITLE
feat: Add reasoning configuration for OpenRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,43 @@
 								"minimum": 0,
 								"maximum": 2,
 								"description": "Repetition penalty (range: (0, 2]). Not required."
+							},
+							"reasoning": {
+								"type": "object",
+								"default": {
+									"effort": "medium"
+								},
+								"properties": {
+									"effort": {
+										"type": "string",
+										"default": "medium",
+										"enum": [
+											"high",
+											"medium",
+											"low",
+											"minimal",
+											"auto"
+										],
+										"description": "Reasoning effort level for OpenRouter/xAI (high, medium, low, minimal, auto)"
+									},
+									"exclude": {
+										"type": "boolean",
+										"default": false,
+										"description": "Exclude reasoning tokens from the final response"
+									},
+									"max_tokens": {
+										"type": "number",
+										"default": 2000,
+										"minimum": 1,
+										"description": "Specific token limit for reasoning (Anthropic-style, alternative to effort)"
+									},
+									"enabled": {
+										"type": "boolean",
+										"default": true,
+										"description": "Enable reasoning (inferred from effort or max_tokens if not specified)"
+									}
+								},
+								"description": "Reasoning configuration for OpenRouter-compatible providers"
 							}
 						},
 						"required": [
@@ -149,6 +186,43 @@
 						]
 					},
 					"description": "A list of preferred models to use. If provided, these models will be used directly instead of fetching from the API."
+				},
+				"oaicopilot.reasoning": {
+					"type": "object",
+					"default": {
+						"effort": "medium"
+					},
+					"properties": {
+						"effort": {
+							"type": "string",
+							"default": "medium",
+							"enum": [
+								"high",
+								"medium",
+								"low",
+								"minimal",
+								"auto"
+							],
+							"description": "Default reasoning effort level for OpenRouter/xAI"
+						},
+						"exclude": {
+							"type": "boolean",
+							"default": false,
+							"description": "Default: Exclude reasoning tokens from the final response"
+						},
+						"max_tokens": {
+							"type": "number",
+							"default": 2000,
+							"minimum": 1,
+							"description": "Default specific token limit for reasoning"
+						},
+						"enabled": {
+							"type": "boolean",
+							"default": true,
+							"description": "Default: Enable reasoning"
+						}
+					},
+					"description": "Global default reasoning configuration for OpenRouter-compatible providers"
 				}
 			}
 		}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -9,7 +9,13 @@ import {
 	Progress,
 } from "vscode";
 
-import type { HFModelItem, HFModelsResponse } from "./types";
+import type {
+	HFModelItem,
+	HFModelsResponse,
+	ReasoningDetail,
+	ReasoningSummaryDetail,
+	ReasoningTextDetail,
+} from "./types";
 
 import { convertTools, convertMessages, tryParseJSONObject, validateRequest } from "./utils";
 
@@ -42,11 +48,11 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	private _textToolActive:
 		| undefined
 		| {
-			name?: string;
-			index?: number;
-			argBuffer: string;
-			emitted?: boolean;
-		};
+				name?: string;
+				index?: number;
+				argBuffer: string;
+				emitted?: boolean;
+		  };
 	private _emittedTextToolCallKeys = new Set<string>();
 	private _emittedTextToolCallIds = new Set<string>();
 
@@ -54,7 +60,10 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	 * Create a provider using the given secret storage for the API key.
 	 * @param secrets VS Code secret storage.
 	 */
-	constructor(private readonly secrets: vscode.SecretStorage, private readonly userAgent: string) { }
+	constructor(
+		private readonly secrets: vscode.SecretStorage,
+		private readonly userAgent: string
+	) {}
 
 	/** Roughly estimate tokens for VS Code chat messages (text only) */
 	private estimateMessagesTokens(msgs: readonly vscode.LanguageModelChatMessage[]): number {
@@ -80,8 +89,12 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	}
 
 	/** Rough token estimate for tool definitions by JSON size */
-	private estimateToolTokens(tools: { type: string; function: { name: string; description?: string; parameters?: object } }[] | undefined): number {
-		if (!tools || tools.length === 0) { return 0; }
+	private estimateToolTokens(
+		tools: { type: string; function: { name: string; description?: string; parameters?: object } }[] | undefined
+	): number {
+		if (!tools || tools.length === 0) {
+			return 0;
+		}
 		try {
 			const json = JSON.stringify(tools);
 			return Math.ceil(json.length / 4);
@@ -107,7 +120,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 
 		// Check for user-configured models first
 		const config = vscode.workspace.getConfiguration();
-		const userModels = config.get<HFModelItem[]>('oaicopilot.models', []);
+		const userModels = config.get<HFModelItem[]>("oaicopilot.models", []);
 
 		let infos: LanguageModelChatInformation[];
 		if (userModels && userModels.length > 0) {
@@ -205,11 +218,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	 * Fetch the list of models and supplementary metadata from Hugging Face.
 	 * @param apiKey The HF API key used to authenticate.
 	 */
-	private async fetchModels(
-		apiKey: string
-	): Promise<{ models: HFModelItem[] }> {
+	private async fetchModels(apiKey: string): Promise<{ models: HFModelItem[] }> {
 		const config = vscode.workspace.getConfiguration();
-		const BASE_URL = config.get<string>('oaicopilot.baseUrl', "");
+		const BASE_URL = config.get<string>("oaicopilot.baseUrl", "");
 		const modelsList = (async () => {
 			const resp = await fetch(`${BASE_URL}/models`, {
 				method: "GET",
@@ -258,7 +269,6 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		progress: Progress<LanguageModelResponsePart>,
 		token: CancellationToken
 	): Promise<void> {
-
 		this._toolCallBuffers.clear();
 		this._completedToolCallIndices.clear();
 		this._hasEmittedAssistantText = false;
@@ -267,7 +277,6 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		this._textToolActive = undefined;
 		this._emittedTextToolCallKeys.clear();
 		this._emittedTextToolCallIds.clear();
-
 
 		let requestBody: Record<string, unknown> | undefined;
 		const trackingProgress: Progress<LanguageModelResponsePart> = {
@@ -296,7 +305,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 
 			// get model config from user settings
 			const config = vscode.workspace.getConfiguration();
-			const userModels = config.get<HFModelItem[]>('oaicopilot.models', []);
+			const userModels = config.get<HFModelItem[]>("oaicopilot.models", []);
 			const um = userModels.find((um) => um.id === model.id);
 
 			// 配置 temperature
@@ -319,16 +328,40 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				stream_options: { include_usage: true },
 				max_tokens: maxTokens,
 				temperature: temperature,
-				top_p: topP
+				top_p: topP,
 			};
 
-			// 配置 enable_thinking
+			const BASE_URL = config.get<string>("oaicopilot.baseUrl", "");
+			const isOpenRouter = BASE_URL.includes("openrouter.ai");
+
+			// 配置 enable_thinking (non-OpenRouter only)
 			const enableThinking = um?.enable_thinking;
-			if (enableThinking !== undefined) {
+			if (enableThinking !== undefined && !isOpenRouter) {
 				(requestBody as Record<string, unknown>).enable_thinking = enableThinking;
 
 				if (um?.thinking_budget !== undefined) {
 					(requestBody as Record<string, unknown>).thinking_budget = um.thinking_budget;
+				}
+			}
+
+			// OpenRouter reasoning configuration
+			if (isOpenRouter) {
+				const reasoningConfig: ReasoningConfig =
+					(um?.reasoning as ReasoningConfig) ?? config.get("oaicopilot.reasoning", { effort: "medium" });
+				if (reasoningConfig.enabled !== false) {
+					const reasoningObj: Record<string, unknown> = {};
+					const effort = reasoningConfig.effort;
+					const maxTokensReasoning = reasoningConfig.max_tokens || 2000; // Default 2000 as per docs
+					if (effort && effort !== "auto") {
+						reasoningObj.effort = effort;
+					} else {
+						// If auto or unspecified, use max_tokens (Anthropic-style fallback)
+						reasoningObj.max_tokens = maxTokensReasoning;
+					}
+					if (reasoningConfig.exclude !== undefined) {
+						reasoningObj.exclude = reasoningConfig.exclude;
+					}
+					(requestBody as Record<string, unknown>).reasoning = reasoningObj;
 				}
 			}
 
@@ -367,7 +400,6 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			}
 
 			// 发送请求
-			const BASE_URL = config.get<string>('oaicopilot.baseUrl', "");
 			const response = await fetch(`${BASE_URL}/chat/completions`, {
 				method: "POST",
 				headers: {
@@ -412,7 +444,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		text: string | LanguageModelChatMessage,
 		_token: CancellationToken
 	): Promise<number> {
-		if (typeof text === 'string') {
+		if (typeof text === "string") {
 			// 纯文本直接估算token
 			return this.estimateTextTokens(text);
 		} else {
@@ -425,7 +457,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					totalTokens += this.estimateTextTokens(part.value);
 				} else if (part instanceof vscode.LanguageModelDataPart) {
 					// 图片或数据部分根据类型估算token
-					if (part.mimeType.startsWith('image/')) {
+					if (part.mimeType.startsWith("image/")) {
 						// 图片大约170个token
 						totalTokens += 170;
 					} else {
@@ -438,7 +470,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					totalTokens += this.estimateTextTokens(toolCallText);
 				} else if (part instanceof vscode.LanguageModelToolResultPart) {
 					// 工具结果的token计算
-					const resultText = typeof part.content === 'string' ? part.content : JSON.stringify(part.content);
+					const resultText = typeof part.content === "string" ? part.content : JSON.stringify(part.content);
 					totalTokens += this.estimateTextTokens(resultText);
 				}
 			}
@@ -480,7 +512,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	private async processStreamingResponse(
 		responseBody: ReadableStream<Uint8Array>,
 		progress: vscode.Progress<vscode.LanguageModelResponsePart>,
-		token: vscode.CancellationToken,
+		token: vscode.CancellationToken
 	): Promise<void> {
 		const reader = responseBody.getReader();
 		const decoder = new TextDecoder();
@@ -489,7 +521,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		try {
 			while (!token.isCancellationRequested) {
 				const { done, value } = await reader.read();
-				if (done) { break; }
+				if (done) {
+					break;
+				}
 
 				buffer += decoder.decode(value, { stream: true });
 				const lines = buffer.split("\n");
@@ -536,19 +570,68 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	 */
 	private async processDelta(
 		delta: Record<string, unknown>,
-		progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+		progress: vscode.Progress<vscode.LanguageModelResponsePart>
 	): Promise<boolean> {
 		let emitted = false;
 		const choice = (delta.choices as Record<string, unknown>[] | undefined)?.[0];
-		if (!choice) { return false; }
+		if (!choice) {
+			return false;
+		}
 
 		const deltaObj = choice.delta as Record<string, unknown> | undefined;
 
-		// report thinking progress if backend provides it and host supports it
+		// Existing thinking/reasoning handling (keep for compatibility)
 		try {
-			const maybeThinking = (choice as Record<string, unknown> | undefined)?.thinking ?? (deltaObj as Record<string, unknown> | undefined)?.thinking ?? (deltaObj as Record<string, unknown> | undefined)?.reasoning_content;
-			if (maybeThinking !== undefined) {
-				const vsAny = (vscode as unknown as Record<string, unknown>);
+			let maybeThinking =
+				(choice as Record<string, unknown> | undefined)?.thinking ??
+				(deltaObj as Record<string, unknown> | undefined)?.thinking ??
+				(deltaObj as Record<string, unknown> | undefined)?.reasoning_content;
+
+			// OpenRouter/Claude reasoning_details array handling (new)
+			const maybeReasoningDetails =
+				(deltaObj as Record<string, unknown>)?.reasoning_details ??
+				(choice as Record<string, unknown>)?.reasoning_details;
+			if (maybeReasoningDetails && Array.isArray(maybeReasoningDetails) && maybeReasoningDetails.length > 0) {
+				// Prioritize details array over simple reasoning
+				const details: Array<ReasoningDetail> = maybeReasoningDetails as Array<ReasoningDetail>;
+				// Sort by index to preserve order (in case out-of-order chunks)
+				const sortedDetails = details.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+
+				for (const detail of sortedDetails) {
+					let extractedText = "";
+					if (detail.type === "reasoning.summary") {
+						extractedText = (detail as ReasoningSummaryDetail).summary;
+					} else if (detail.type === "reasoning.text") {
+						extractedText = (detail as ReasoningTextDetail).text;
+					} else if (detail.type === "reasoning.encrypted") {
+						extractedText = "[REDACTED]"; // As per docs
+					} else {
+						extractedText = JSON.stringify(detail); // Fallback for unknown
+					}
+
+					if (extractedText) {
+						const vsAny = vscode as unknown as Record<string, unknown>;
+						const ThinkingCtor = vsAny["LanguageModelThinkingPart"] as
+							| (new (text: string, id?: string, metadata?: unknown) => unknown)
+							| undefined;
+						if (ThinkingCtor) {
+							const metadata = { format: detail.format, type: detail.type, index: detail.index };
+							const thinkingPart = new (ThinkingCtor as new (text: string, id?: string, metadata?: unknown) => unknown)(
+								extractedText,
+								detail.id || undefined, // Handle null as undefined
+								metadata
+							) as unknown as vscode.LanguageModelResponsePart;
+							progress.report(thinkingPart);
+							emitted = true;
+						}
+					}
+				}
+				maybeThinking = null; // Skip simple thinking if details present
+			}
+
+			// Fallback to simple thinking if no details
+			if (maybeThinking !== undefined && maybeThinking !== null) {
+				const vsAny = vscode as unknown as Record<string, unknown>;
 				const ThinkingCtor = vsAny["LanguageModelThinkingPart"] as
 					| (new (text: string, id?: string, metadata?: unknown) => unknown)
 					| undefined;
@@ -558,21 +641,27 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					let metadata: unknown;
 					if (maybeThinking && typeof maybeThinking === "object") {
 						const mt = maybeThinking as Record<string, unknown>;
-						text = typeof mt["text"] === "string" ? (mt["text"] as string) : "";
+						text = typeof mt["text"] === "string" ? (mt["text"] as string) : JSON.stringify(mt);
 						id = typeof mt["id"] === "string" ? (mt["id"] as string) : undefined;
-						metadata = mt["metadata"];
+						metadata = mt["metadata"] ?? mt;
 					} else if (typeof maybeThinking === "string") {
 						text = maybeThinking;
 					}
 					if (text) {
-						progress.report(new (ThinkingCtor as new (text: string, id?: string, metadata?: unknown) => unknown)(text, id, metadata) as unknown as vscode.LanguageModelResponsePart);
+						const thinkingPart = new (ThinkingCtor as new (text: string, id?: string, metadata?: unknown) => unknown)(
+							text,
+							id,
+							metadata
+						) as unknown as vscode.LanguageModelResponsePart;
+						progress.report(thinkingPart);
 						emitted = true;
 					}
 				}
 			}
-		} catch {
-			// ignore errors here temporarily
+		} catch (e) {
+			console.warn("[OAI Compatible Model Provider] Failed to process thinking/reasoning_details:", e);
 		}
+
 		if (deltaObj?.content) {
 			const content = String(deltaObj.content);
 			const res = this.processTextContent(content, progress);
@@ -632,7 +721,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	 */
 	private processTextContent(
 		input: string,
-		progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+		progress: vscode.Progress<vscode.LanguageModelResponsePart>
 	): { emittedText: boolean; emittedAny: boolean } {
 		const BEGIN = "<|tool_call_begin|>";
 		const ARG_BEGIN = "<|tool_call_argument_begin|>";
@@ -648,15 +737,19 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				const b = data.indexOf(BEGIN);
 				if (b === -1) {
 					// No tool-call start: emit visible portion, but keep any partial BEGIN prefix as buffer
-					const longestPartialPrefix = ((): number => {
+					const longestPartialPrefix = (() => {
 						for (let k = Math.min(BEGIN.length - 1, data.length - 1); k > 0; k--) {
-							if (data.endsWith(BEGIN.slice(0, k))) { return k; }
+							if (data.endsWith(BEGIN.slice(0, k))) {
+								return k;
+							}
 						}
 						return 0;
 					})();
 					if (longestPartialPrefix > 0) {
 						const visible = data.slice(0, data.length - longestPartialPrefix);
-						if (visible) { visibleOut += this.stripControlTokens(visible); }
+						if (visible) {
+							visibleOut += this.stripControlTokens(visible);
+						}
 						this._textToolParserBuffer = data.slice(data.length - longestPartialPrefix);
 						data = "";
 						break;
@@ -680,9 +773,13 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				const e = data.indexOf(END);
 				let delimIdx = -1;
 				let delimKind: "arg" | "end" | undefined = undefined;
-				if (a !== -1 && (e === -1 || a < e)) { delimIdx = a; delimKind = "arg"; }
-				else if (e !== -1) { delimIdx = e; delimKind = "end"; }
-				else {
+				if (a !== -1 && (e === -1 || a < e)) {
+					delimIdx = a;
+					delimKind = "arg";
+				} else if (e !== -1) {
+					delimIdx = e;
+					delimKind = "end";
+				} else {
 					// Incomplete header; keep for next chunk (re-add BEGIN so we don't lose it)
 					this._textToolParserBuffer = BEGIN + data;
 					data = "";
@@ -697,7 +794,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				// Advance past delimiter token
 				if (delimKind === "arg") {
 					data = data.slice(delimIdx + ARG_BEGIN.length);
-				} else /* end */ {
+				} /* end */ else {
 					// No args, finalize immediately
 					data = data.slice(delimIdx + END.length);
 					const did = this.emitTextToolCallIfValid(progress, this._textToolActive, "{}");
@@ -758,7 +855,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	private emitTextToolCallIfValid(
 		progress: vscode.Progress<vscode.LanguageModelResponsePart>,
 		call: { name?: string; index?: number; argBuffer: string; emitted?: boolean },
-		argText: string,
+		argText: string
 	): boolean {
 		const name = call.name ?? "unknown_tool";
 		const parsed = tryParseJSONObject(argText);
@@ -784,9 +881,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		return true;
 	}
 
-	private async flushActiveTextToolCall(
-		progress: vscode.Progress<vscode.LanguageModelResponsePart>,
-	): Promise<void> {
+	private async flushActiveTextToolCall(progress: vscode.Progress<vscode.LanguageModelResponsePart>): Promise<void> {
 		if (!this._textToolActive) {
 			return;
 		}
@@ -825,7 +920,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		try {
 			const canonical = JSON.stringify(parameters);
 			this._emittedTextToolCallKeys.add(`${buf.name}:${canonical}`);
-		} catch { /* ignore */ }
+		} catch {
+			/* ignore */
+		}
 		progress.report(new vscode.LanguageModelToolCallPart(id, buf.name, parameters));
 		this._toolCallBuffers.delete(index);
 		this._completedToolCallIndices.add(index);
@@ -838,7 +935,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	 */
 	private async flushToolCallBuffers(
 		progress: vscode.Progress<vscode.LanguageModelResponsePart>,
-		throwOnInvalid: boolean,
+		throwOnInvalid: boolean
 	): Promise<void> {
 		if (this._toolCallBuffers.size === 0) {
 			return;
@@ -847,7 +944,10 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			const parsed = tryParseJSONObject(buf.args);
 			if (!parsed.ok) {
 				if (throwOnInvalid) {
-					console.error("[OAI Compatible Model Provider] Invalid JSON for tool call", { idx, snippet: (buf.args || "").slice(0, 200) });
+					console.error("[OAI Compatible Model Provider] Invalid JSON for tool call", {
+						idx,
+						snippet: (buf.args || "").slice(0, 200),
+					});
 					throw new Error("Invalid JSON for tool call");
 				}
 				// When not throwing (e.g. on [DONE]), drop silently to reduce noise
@@ -858,7 +958,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			try {
 				const canonical = JSON.stringify(parsed.value);
 				this._emittedTextToolCallKeys.add(`${name}:${canonical}`);
-			} catch { /* ignore */ }
+			} catch {
+				/* ignore */
+			}
 			progress.report(new vscode.LanguageModelToolCallPart(id, name, parsed.value));
 			this._toolCallBuffers.delete(idx);
 			this._completedToolCallIndices.add(idx);
@@ -876,5 +978,12 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			return text;
 		}
 	}
+}
 
+// Add this interface at the top of the file, after imports
+interface ReasoningConfig {
+	effort?: string;
+	exclude?: boolean;
+	max_tokens?: number;
+	enabled?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface OpenAIChatMessage {
  * 聊天消息内容接口（支持多模态）
  */
 export interface ChatMessageContent {
-	type: 'text' | 'image_url';
+	type: "text" | "image_url";
 	text?: string;
 	image_url?: {
 		url: string;
@@ -75,6 +75,12 @@ export interface HFModelItem {
 	frequency_penalty?: number;
 	presence_penalty?: number;
 	repetition_penalty?: number;
+	reasoning?: {
+		effort?: string;
+		exclude?: boolean;
+		max_tokens?: number;
+		enabled?: boolean;
+	};
 }
 
 /**
@@ -105,3 +111,27 @@ export interface ToolCallBuffer {
 
 /** OpenAI-style chat roles. */
 export type OpenAIChatRole = "system" | "user" | "assistant" | "tool";
+
+export interface ReasoningDetailCommon {
+	id: string | null;
+	format: string; // e.g., "anthropic-claude-v1", "openai-responses-v1"
+	index?: number;
+}
+
+export interface ReasoningSummaryDetail extends ReasoningDetailCommon {
+	type: "reasoning.summary";
+	summary: string;
+}
+
+export interface ReasoningEncryptedDetail extends ReasoningDetailCommon {
+	type: "reasoning.encrypted";
+	data: string; // Base64 encoded
+}
+
+export interface ReasoningTextDetail extends ReasoningDetailCommon {
+	type: "reasoning.text";
+	text: string;
+	signature?: string | null;
+}
+
+export type ReasoningDetail = ReasoningSummaryDetail | ReasoningEncryptedDetail | ReasoningTextDetail;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"module": "Node16",
 		"target": "ES2024",
-		"lib": ["ES2024"],
+		"lib": ["ES2024", "dom"],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true /* enable all strict type-checking options */,


### PR DESCRIPTION
### Issue
[How can set the effort variable of the reasoning model? #5
](https://github.com/JohnnyZ93/oai-compatible-copilot/issues/5)

### Description
This PR integrates OpenRouter's reasoning features into the OAI-Compatible Copilot extension, supporting configurable effort levels (high/medium/low/minimal/auto) and parsing of reasoning_details. This enables chain-of-thought display in Copilot Chat via LanguageModelThinkingPart, while maintaining compatibility with Hugging Face's enable_thinking.

### Key Changes
- **Configuration (package.json)**: Added oaicopilot.reasoning global/per-model object with effort, exclude, max_tokens, enabled.
- **Types (types.ts)**: New interfaces for ReasoningDetail. 
- **Request Handling (provider.ts)**: Detect OpenRouter via `baseUrl` and add `reasoning` object to API payload. preserve enable_thinking for non-OpenRouter.
- **Response Parsing (provider.ts)**: In `processDelta`, parse `reasoning_details` array by type. emit parsed data as `LanguageModelThinkingPart` sorted by index for CoT display in chat UI.

### Testing
- **Setup**: `npm run compile` (no errors) and launched extension in VS Code Extension Host (F5).
- **Configuration**: Set `baseUrl` to `https://openrouter.ai/api/v1` and added models (`xai/grok-4-fast:free`, `google/gemini-flash-2.5`)
```
 "oaicopilot.baseUrl": "https://openrouter.ai/api/v1",
  "oaicopilot.models": [
    {
      "id": "x-ai/grok-4-fast:free",
      "owned_by": "openrouter",
      "context_length": 2000000,
      "max_tokens": 400000,
      "temperature": 0,
      "reasoning": {
        "enabled": true,
        "effort": "high"
      }
    },
    {
      "id": "google/gemini-2.5-flash",
      "owned_by": "openrouter",
      "context_length": 1000000,
      "max_tokens": 60000,
      "temperature": 0,
      "reasoning": {
        "enabled": true,
        "exclude": false
      }
    }
  ]
```
- **Copilot Chat**: Each model was selected and tested in Copilot Chat. For models that support CoT output (`google/gemini-2.5-flash`), the CoT stage was output in the Chat UI. For models that do not support CoT output (`x-ai/grok-4-fast:free`), the empty `reasoning_details` array was processed without errors.

### Screenshoots
<table>
<tr>
<td><img width="401" height="702" alt="1" src="https://github.com/user-attachments/assets/4e693c77-b03d-4c1b-8047-d47cd9b69e88" /></td>
<td><img width="411" height="737" alt="2" src="https://github.com/user-attachments/assets/35e74de9-45d2-4d9a-9ac7-09dcb88bbcde" /></td>
</tr>
</table>
