### PR TITLE
feat: add support for extra configuration parameters 

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -362,6 +362,16 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			rb.repetition_penalty = um.repetition_penalty;
 		}
 
+		// Process extra configuration parameters
+		if (um?.extra && typeof um.extra === "object") {
+			// Add all extra parameters directly to the request body
+			for (const [key, value] of Object.entries(um.extra)) {
+				if (value !== undefined) {
+					rb[key] = value;
+				}
+			}
+		}
+
 		return rb;
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,13 @@ export interface HFModelItem {
 	 * defaults to "oai-compatible".
 	 */
 	family?: string;
+
+	/**
+	 * Extra configuration parameters that can be used for custom functionality.
+	 * This allows users to add any additional parameters they might need
+	 * without modifying the core interface.
+	 */
+	extra?: Record<string, any>;
 }
 
 /**


### PR DESCRIPTION
Expanded model fields and added `extra` configuration support.  
This change enables including additional metadata or parameters in request definitions,  
including those not natively supported by the extension.

Example:
```json
{
  "oaicopilot.models": [
    {
      "id": "gpt-5",
      "owned_by": "org",
      "extra": {
        "allowed_openai_params": ["top_p", "temperature"]
      },
      "top_p": 1,
      "temperature": 1
    }
  ]
}
```
