### PR TITLE
feat: add Responses + Gemini native API modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+- Feat: Add OpenAI Responses API mode (`apiMode: "openai-responses"`, endpoint `/responses`).
+- Feat: Add Gemini native API mode (`apiMode: "gemini"`, endpoint `.../v1beta/models/{model}:streamGenerateContent?alt=sse`).
+- Fix: Preserve Gemini `thoughtSignature` for tool-calling follow-up requests (required by newer Gemini thinking models).
+- Fix: Accept `provider` / `provide` as aliases of `owned_by` in `oaicopilot.models`.
+- Fix: Anthropic mode sends `anthropic-version: 2023-06-01` and includes request URL in errors for easier relay debugging.
+
 ## 0.2.0 (2025-12-25)
 
 - Fix: [Text content blocks must be non-empty on Anthropic api](https://github.com/JohnnyZ93/oai-compatible-copilot/issues/79)

--- a/README.md
+++ b/README.md
@@ -103,24 +103,34 @@ There are two ways to open the configuration interface:
 
 ## * Multi Api Mode
 
-The extension supports three different API protocols to work with various model providers. You can specify which API mode to use for each model via the `apiMode` parameter.
+The extension supports five different API protocols to work with various model providers. You can specify which API mode to use for each model via the `apiMode` parameter.
 
 ### Supported API Modes
 
-1. **`openai`** (default) - OpenAI-compatible API
+1. **`openai`** (default) - OpenAI Chat Completions API
    - Endpoint: `/chat/completions`
    - Header: `Authorization: Bearer <apiKey>`
    - Use for: Most OpenAI-compatible providers (ModelScope, SiliconFlow, etc.)
 
-2. **`ollama`** - Ollama native API
+2. **`openai-responses`** - OpenAI Responses API
+   - Endpoint: `/responses`
+   - Header: `Authorization: Bearer <apiKey>`
+   - Use for: OpenAI official Responses API (and compatible gateways like rsp4copilot)
+
+3. **`ollama`** - Ollama native API
    - Endpoint: `/api/chat`
    - Header: `Authorization: Bearer <apiKey>` (or no header for local Ollama)
    - Use for: Local Ollama instances
 
-3. **`anthropic`** - Anthropic Claude API
+4. **`anthropic`** - Anthropic Claude API
    - Endpoint: `/v1/messages`
    - Header: `x-api-key: <apiKey>`
    - Use for: Anthropic Claude models
+
+5. **`gemini`** - Gemini native API
+   - Endpoint: `/v1beta/models/{model}:streamGenerateContent?alt=sse`
+   - Header: `x-goog-api-key: <apiKey>`
+   - Use for: Google Gemini models (and compatible gateways like rsp4copilot)
 
 ### Configuration Examples
 Mixed configuration with multiple API modes:
@@ -154,7 +164,7 @@ Mixed configuration with multiple API modes:
 
 ## * Multi-Provider Guide
 
-> `owned_by` in model config is used for group apiKey. The storage key is `oaicopilot.apiKey.${owned_by}`.
+> `owned_by` (alias: `provider` / `provide`) in model config is used for grouping provider-specific apiKey. The storage key is `oaicopilot.apiKey.<providerIdLowercase>`.
 
 1. Open VS Code Settings and configure `oaicopilot.models`.
 2. Open command center ( Ctrl + Shift + P ), and search "OAICopilot: Set OAI Compatible Multi-Provider Apikey" to configure provider-specific API keys.
@@ -359,7 +369,7 @@ All parameters support individual configuration for different models, providing 
 - `headers`: Custom HTTP headers to be sent with every request to this model's provider (e.g., `{"X-API-Version": "v1", "X-Custom-Header": "value"}`). These headers will be merged with the default headers (Authorization, Content-Type, User-Agent)
 - `extra`: Extra request body parameters.
 - `include_reasoning_in_request`: Whether to include reasoning_content in assistant messages sent to the API. Support deepseek-v3.2 or others.
-- `apiMode`: API mode: 'openai' (Default) for API (/chat/completions), 'ollama' for API (/api/chat), 'anthropic' for API (/v1/messages).
+- `apiMode`: API mode: 'openai' (Default) for API (/chat/completions), 'openai-responses' for API (/responses), 'ollama' for API (/api/chat), 'anthropic' for API (/v1/messages), 'gemini' for API (/v1beta/models/{model}:streamGenerateContent?alt=sse).
 - `delay`: Model-specific delay in milliseconds between consecutive requests. If not specified, falls back to global `oaicopilot.delay` configuration.
 ---
 

--- a/assets/configView/configView.html
+++ b/assets/configView/configView.html
@@ -142,12 +142,14 @@
 						<div class="field">
 							<label for="modelApiMode">API Mode</label>
 							<div class="field-description">
-								'openai'for API (/chat/completions), 'ollama' for API (/api/chat), 'anthropic' for API (/v1/messages).
+								'openai' for API (/chat/completions), 'openai-responses' for API (/responses), 'ollama' for API (/api/chat), 'anthropic' for API (/v1/messages), 'gemini' for API (/v1beta/models/{model}:streamGenerateContent?alt=sse).
 							</div>
 							<select id="modelApiMode" class="model-input">
 								<option value="openai">OpenAI</option>
+								<option value="openai-responses">OpenAI Responses</option>
 								<option value="ollama">Ollama</option>
 								<option value="anthropic">Anthropic</option>
+								<option value="gemini">Gemini</option>
 							</select>
 						</div>
 					</div>

--- a/assets/configView/configView.js
+++ b/assets/configView/configView.js
@@ -119,8 +119,10 @@ document.getElementById("addProvider").addEventListener("click", () => {
 		<td>
 			<select class="provider-input" data-field="apiMode">
 				<option value="openai">OpenAI</option>
+				<option value="openai-responses">OpenAI Responses</option>
 				<option value="ollama">Ollama</option>
 				<option value="anthropic">Anthropic</option>
+				<option value="gemini">Gemini</option>
 			</select>
 		</td>
 		<td>
@@ -311,8 +313,10 @@ function renderProviders() {
 				<td>
 					<select class="provider-input" data-field="apiMode">
 						<option value="openai" ${firstModel.apiMode === "openai" ? "selected" : ""}>OpenAI</option>
+						<option value="openai-responses" ${firstModel.apiMode === "openai-responses" ? "selected" : ""}>OpenAI Responses</option>
 						<option value="ollama" ${firstModel.apiMode === "ollama" ? "selected" : ""}>Ollama</option>
 						<option value="anthropic" ${firstModel.apiMode === "anthropic" ? "selected" : ""}>Anthropic</option>
+						<option value="gemini" ${firstModel.apiMode === "gemini" ? "selected" : ""}>Gemini</option>
 					</select>
 				</td>
 				<td>

--- a/package.json
+++ b/package.json
@@ -97,6 +97,14 @@
 								"type": "string",
 								"description": "Model provider (e.g., 'zai', 'openai')."
 							},
+							"provider": {
+								"type": "string",
+								"description": "(Alias of owned_by) Model provider (e.g., 'zai', 'openai')."
+							},
+							"provide": {
+								"type": "string",
+								"description": "(Alias of owned_by) Model provider (e.g., 'zai', 'openai')."
+							},
 							"family": {
 								"type": "string",
 								"description": "Model family (e.g., 'gpt-4', 'claude-3', 'gemini'). Enables model-specific optimizations and behaviors. Defaults to 'oai-compatible' if not specified."
@@ -273,11 +281,13 @@
 								"type": "string",
 								"enum": [
 									"openai",
+									"openai-responses",
 									"ollama",
-									"anthropic"
+									"anthropic",
+									"gemini"
 								],
 								"default": "openai",
-								"description": "API mode: 'openai' (Default) for API (/chat/completions), 'ollama' for API (/api/chat), 'anthropic' for API (/v1/messages)."
+								"description": "API mode: 'openai' (Default) for OpenAI Chat Completions (/chat/completions), 'openai-responses' for OpenAI Responses (/responses), 'ollama' for Ollama (/api/chat), 'anthropic' for Anthropic (/v1/messages), 'gemini' for Gemini (*/v1beta/models/{model}:streamGenerateContent?alt=sse)."
 							},
 							"delay": {
 								"type": "number",
@@ -286,10 +296,8 @@
 								"description": "Model-specific delay in milliseconds between consecutive requests. If not specified, falls back to global oaicopilot.delay configuration."
 							}
 						},
-						"required": [
-							"id",
-							"owned_by"
-						]
+						"required": ["id"],
+						"anyOf": [{ "required": ["owned_by"] }, { "required": ["provider"] }, { "required": ["provide"] }]
 					},
 					"description": "A list of preferred models to use. If provided, these models will be used directly instead of fetching from the API."
 				},

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -22,7 +22,7 @@ import { isImageMimeType, isToolResultPart, collectToolResultText, convertToolsT
 
 import { CommonApi } from "../commonApi";
 
-export class AnthropicApi extends CommonApi {
+export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBody> {
 	private _systemContent: string | undefined;
 
 	constructor() {

--- a/src/commonApi.ts
+++ b/src/commonApi.ts
@@ -7,15 +7,10 @@ import {
 	Progress,
 	CancellationToken,
 } from "vscode";
-
-import type { OllamaMessage, OllamaRequestBody } from "./ollama/ollamaTypes";
-
-import type { OpenAIChatMessage } from "./openai/openaiTypes";
-import type { AnthropicMessage, AnthropicRequestBody } from "./anthropic/anthropicTypes";
 import { HFModelItem } from "./types";
 import { tryParseJSONObject } from "./utils";
 
-export abstract class CommonApi {
+export abstract class CommonApi<TMessage, TRequestBody> {
 	/** Buffer for assembling streamed tool calls by index. */
 	protected _toolCallBuffers: Map<number, { id?: string; name?: string; args: string }> = new Map<
 		number,
@@ -55,7 +50,7 @@ export abstract class CommonApi {
 	abstract convertMessages(
 		messages: readonly LanguageModelChatRequestMessage[],
 		modelConfig: { includeReasoningInRequest: boolean }
-	): Array<OpenAIChatMessage | OllamaMessage | AnthropicMessage>;
+	): TMessage[];
 
 	/**
 	 * Construct request body for Specific api
@@ -64,10 +59,10 @@ export abstract class CommonApi {
 	 * @param options From VS Code
 	 */
 	abstract prepareRequestBody(
-		rb: Record<string, unknown> | OllamaRequestBody | AnthropicRequestBody,
+		rb: TRequestBody,
 		um: HFModelItem | undefined,
 		options: ProvideLanguageModelChatResponseOptions
-	): Record<string, unknown> | OllamaRequestBody | AnthropicRequestBody;
+	): TRequestBody;
 
 	/**
 	 * Process specific api streaming response (JSON lines format).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { HuggingFaceChatModelProvider } from "./provider";
 import type { HFModelItem } from "./types";
 import { initStatusBar } from "./statusBar";
 import { ConfigViewPanel } from "./views/configView";
+import { normalizeUserModels } from "./utils";
 
 export function activate(context: vscode.ExtensionContext) {
 	// Build a descriptive User-Agent to help quantify API usage
@@ -46,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand("oaicopilot.setProviderApikey", async () => {
 			// Get provider list from configuration
 			const config = vscode.workspace.getConfiguration();
-			const userModels = config.get<HFModelItem[]>("oaicopilot.models", []);
+			const userModels = normalizeUserModels(config.get<HFModelItem[]>("oaicopilot.models", []));
 
 			// Extract unique providers (case-insensitive)
 			const providers = Array.from(

--- a/src/gemini/geminiApi.ts
+++ b/src/gemini/geminiApi.ts
@@ -1,0 +1,804 @@
+import * as vscode from "vscode";
+import {
+	CancellationToken,
+	LanguageModelChatRequestMessage,
+	ProvideLanguageModelChatResponseOptions,
+	LanguageModelResponsePart2,
+	Progress,
+} from "vscode";
+
+import type { HFModelItem } from "../types";
+import type { OpenAIFunctionToolDef } from "../openai/openaiTypes";
+
+import { CommonApi } from "../commonApi";
+
+import { isImageMimeType, isToolResultPart, collectToolResultText, convertToolsToOpenAI, mapRole, tryParseJSONObject } from "../utils";
+
+import type {
+	GeminiGenerateContentRequest,
+	GeminiGenerateContentResponse,
+	GeminiPart,
+	GeminiToolConfig,
+} from "./geminiTypes";
+
+export interface GeminiChatMessage {
+	role: "user" | "model" | "system";
+	parts: GeminiPart[];
+}
+
+export interface GeminiToolCallMeta {
+	name: string;
+	thoughtSignature?: string;
+	thought?: string;
+	createdAt: number;
+}
+
+function normalizeBaseUrl(raw: string): string {
+	const v = (raw || "").trim();
+	if (!v) {
+		return "";
+	}
+	try {
+		return new URL(v).toString();
+	} catch {
+		// Try to recover from missing scheme
+		if (!/^https?:\/\//i.test(v)) {
+			try {
+				return new URL(`https://${v}`).toString();
+			} catch {
+				return v;
+			}
+		}
+		return v;
+	}
+}
+
+function joinPathPrefix(basePath: string, nextPath: string): string {
+	const a = basePath || "";
+	const b = nextPath || "";
+	const aTrim = a.endsWith("/") ? a.slice(0, -1) : a;
+	const bTrim = b.startsWith("/") ? b : `/${b}`;
+	return `${aTrim || ""}${bTrim}`;
+}
+
+function normalizeGeminiModelPath(modelId: string): string {
+	const raw = (modelId || "").trim();
+	if (!raw) {
+		return "models/gemini-3-pro-preview";
+	}
+
+	const last = raw.includes("/") ? raw.split("/").filter(Boolean).pop() || raw : raw;
+	if (last.startsWith("models/") || last.startsWith("tunedModels/")) {
+		return last;
+	}
+
+	if (last.includes("..") || last.includes("?") || last.includes("&")) {
+		return "";
+	}
+
+	return `models/${last}`;
+}
+
+export function buildGeminiGenerateContentUrl(rawBaseUrl: string, modelId: string, stream: boolean): string {
+	const value = (rawBaseUrl || "").trim();
+	if (!value) {
+		return "";
+	}
+
+	try {
+		const normalized = normalizeBaseUrl(value);
+		const u0 = new URL(normalized);
+		let basePath = (u0.pathname || "").replace(/\/+$/, "") || "/";
+
+		// If configured as a full endpoint, keep it (just switch method based on stream).
+		if (/:generateContent$/i.test(basePath) || /:streamGenerateContent$/i.test(basePath)) {
+			const method = stream ? "streamGenerateContent" : "generateContent";
+			u0.pathname = basePath.replace(/:(streamGenerateContent|generateContent)$/i, `:${method}`);
+			u0.search = "";
+			u0.hash = "";
+			if (stream) {
+				u0.searchParams.set("alt", "sse");
+			}
+			return u0.toString();
+		}
+
+		const modelPath = normalizeGeminiModelPath(modelId);
+		if (!modelPath) {
+			return "";
+		}
+
+		// If base already contains a version segment, don't append again.
+		if (!/\/v1beta$/i.test(basePath) && !/\/v1beta\//i.test(`${basePath}/`)) {
+			basePath = joinPathPrefix(basePath, "/v1beta");
+		}
+
+		const method = stream ? "streamGenerateContent" : "generateContent";
+		u0.pathname = joinPathPrefix(basePath, `/${modelPath}:${method}`);
+		u0.search = "";
+		u0.hash = "";
+		if (stream) {
+			u0.searchParams.set("alt", "sse");
+		}
+		return u0.toString();
+	} catch {
+		return "";
+	}
+}
+
+function jsonSchemaToGeminiSchema(
+	jsonSchema: unknown,
+	rootSchema: unknown = jsonSchema,
+	refStack: Set<string> | undefined = undefined
+): Record<string, unknown> {
+	if (!jsonSchema || typeof jsonSchema !== "object") {
+		return {};
+	}
+
+	const root = rootSchema && typeof rootSchema === "object" ? (rootSchema as Record<string, unknown>) : (jsonSchema as Record<string, unknown>);
+	const stack = refStack instanceof Set ? refStack : new Set<string>();
+
+	const ref = typeof (jsonSchema as Record<string, unknown>).$ref === "string" ? String((jsonSchema as Record<string, unknown>).$ref).trim() : "";
+	if (ref) {
+		if (stack.has(ref)) {
+			return {};
+		}
+		stack.add(ref);
+
+		const resolved = (() => {
+			if (ref === "#") {
+				return root;
+			}
+			if (!ref.startsWith("#/")) {
+				return null;
+			}
+			const decode = (token: string) => token.replace(/~1/g, "/").replace(/~0/g, "~");
+			const parts = ref
+				.slice(2)
+				.split("/")
+				.map((p) => decode(p));
+
+			let cur: unknown = root;
+			for (const p of parts) {
+				if (!cur || typeof cur !== "object") {
+					return null;
+				}
+				if (!(p in (cur as Record<string, unknown>))) {
+					return null;
+				}
+				cur = (cur as Record<string, unknown>)[p];
+			}
+			return cur && typeof cur === "object" ? (cur as Record<string, unknown>) : null;
+		})();
+
+		const merged: Record<string, unknown> = {
+			...(resolved && typeof resolved === "object" ? (resolved as Record<string, unknown>) : {}),
+			...(jsonSchema as Record<string, unknown>),
+		};
+		delete merged.$ref;
+		const out = jsonSchemaToGeminiSchema(merged, root, stack);
+		stack.delete(ref);
+		return out;
+	}
+
+	const allOf = Array.isArray((jsonSchema as Record<string, unknown>).allOf) ? ((jsonSchema as Record<string, unknown>).allOf as unknown[]) : null;
+	if (allOf && allOf.length > 0) {
+		const merged: Record<string, unknown> = { ...(jsonSchema as Record<string, unknown>) };
+		delete merged.allOf;
+		for (const it of allOf) {
+			if (!it || typeof it !== "object") {
+				continue;
+			}
+			const itObj = it as Record<string, unknown>;
+			for (const [k, v] of Object.entries(itObj)) {
+				if (k === "properties" && v && typeof v === "object" && !Array.isArray(v)) {
+					const baseProps = merged.properties && typeof merged.properties === "object" && !Array.isArray(merged.properties) ? (merged.properties as Record<string, unknown>) : {};
+					merged.properties = { ...baseProps, ...(v as Record<string, unknown>) };
+					continue;
+				}
+				if (k === "required" && Array.isArray(v)) {
+					const baseReq = Array.isArray(merged.required) ? (merged.required as unknown[]) : [];
+					merged.required = Array.from(new Set([...baseReq, ...v]));
+					continue;
+				}
+				if (!(k in merged)) {
+					merged[k] = v;
+				}
+			}
+		}
+		return jsonSchemaToGeminiSchema(merged, root, stack);
+	}
+
+	const out: Record<string, unknown> = {};
+	const input = { ...(jsonSchema as Record<string, unknown>) };
+
+	// Handle nullable unions like { anyOf: [{type:'null'}, {...}] }
+	const anyOf = Array.isArray(input.anyOf) ? (input.anyOf as unknown[]) : Array.isArray(input.oneOf) ? (input.oneOf as unknown[]) : null;
+	if (anyOf && anyOf.length === 2) {
+		const a0 = anyOf[0] && typeof anyOf[0] === "object" ? (anyOf[0] as Record<string, unknown>) : null;
+		const a1 = anyOf[1] && typeof anyOf[1] === "object" ? (anyOf[1] as Record<string, unknown>) : null;
+		if (a0?.type === "null") {
+			out.nullable = true;
+			return { ...out, ...jsonSchemaToGeminiSchema(a1, root, stack) };
+		}
+		if (a1?.type === "null") {
+			out.nullable = true;
+			return { ...out, ...jsonSchemaToGeminiSchema(a0, root, stack) };
+		}
+	}
+
+	if (Array.isArray(input.type)) {
+		const list = (input.type as unknown[]).filter((t) => typeof t === "string");
+		if (list.length) {
+			out.anyOf = list
+				.filter((t) => t !== "null")
+				.map((t) => jsonSchemaToGeminiSchema({ ...input, type: t, anyOf: undefined, oneOf: undefined }, root, stack));
+			if (list.includes("null")) {
+				out.nullable = true;
+			}
+			return out;
+		}
+	}
+
+	for (const [k, v] of Object.entries(input)) {
+		if (v == null) {
+			continue;
+		}
+		if (k.startsWith("$")) {
+			continue;
+		}
+		if (k === "additionalProperties" || k === "definitions" || k === "$defs" || k === "title" || k === "examples" || k === "default") {
+			continue;
+		}
+		if (k === "allOf") {
+			continue;
+		}
+
+		if (k === "type") {
+			if (typeof v !== "string") {
+				continue;
+			}
+			if (v === "null") {
+				continue;
+			}
+			out.type = String(v).toUpperCase();
+			continue;
+		}
+
+		if (k === "const") {
+			if (!("enum" in out)) {
+				out.enum = [v];
+			}
+			continue;
+		}
+
+		if (k === "items") {
+			if (v && typeof v === "object") {
+				out.items = jsonSchemaToGeminiSchema(v, root, stack);
+			}
+			continue;
+		}
+
+		if (k === "properties") {
+			if (v && typeof v === "object" && !Array.isArray(v)) {
+				const m: Record<string, unknown> = {};
+				for (const [pk, pv] of Object.entries(v as Record<string, unknown>)) {
+					if (pv && typeof pv === "object") {
+						m[pk] = jsonSchemaToGeminiSchema(pv, root, stack);
+					}
+				}
+				out.properties = m;
+			}
+			continue;
+		}
+
+		if (k === "anyOf" || k === "oneOf") {
+			if (Array.isArray(v)) {
+				const arr: unknown[] = [];
+				for (const it of v) {
+					if (it && typeof it === "object") {
+						arr.push(jsonSchemaToGeminiSchema(it, root, stack));
+					}
+				}
+				out.anyOf = arr;
+			}
+			continue;
+		}
+
+		(out as Record<string, unknown>)[k] = v;
+	}
+
+	// Gemini Schema types are enum-like uppercase strings; if absent but properties exist, treat as OBJECT.
+	if (!out.type && out.properties && typeof out.properties === "object") {
+		out.type = "OBJECT";
+	}
+
+	return out;
+}
+
+function openaiToolsToGeminiFunctionDeclarations(tools: OpenAIFunctionToolDef[]): Array<{ name: string; description?: string; parameters?: Record<string, unknown> }> {
+	const out: Array<{ name: string; description?: string; parameters?: Record<string, unknown> }> = [];
+	for (const t of Array.isArray(tools) ? tools : []) {
+		if (!t || typeof t !== "object") {
+			continue;
+		}
+		if (t.type !== "function") {
+			continue;
+		}
+		const fn = t.function;
+		const name = typeof fn?.name === "string" ? fn.name.trim() : "";
+		if (!name) {
+			continue;
+		}
+		const decl: { name: string; description?: string; parameters?: Record<string, unknown> } = { name };
+		if (typeof fn.description === "string" && fn.description.trim()) {
+			decl.description = fn.description;
+		}
+		if (fn.parameters && typeof fn.parameters === "object") {
+			decl.parameters = jsonSchemaToGeminiSchema(fn.parameters);
+		}
+		out.push(decl);
+	}
+	return out;
+}
+
+function openaiToolChoiceToGeminiToolConfig(toolChoice: unknown): GeminiToolConfig | null {
+	if (toolChoice == null) {
+		return null;
+	}
+
+	if (typeof toolChoice === "string") {
+		const v = toolChoice.trim().toLowerCase();
+		if (v === "none") {
+			return { functionCallingConfig: { mode: "NONE" } };
+		}
+		if (v === "required" || v === "any") {
+			return { functionCallingConfig: { mode: "ANY" } };
+		}
+		return { functionCallingConfig: { mode: "AUTO" } };
+	}
+
+	if (typeof toolChoice === "object") {
+		const obj = toolChoice as Record<string, unknown>;
+		if (obj.type === "function") {
+			const fn = obj.function && typeof obj.function === "object" ? (obj.function as Record<string, unknown>) : null;
+			const name = fn && typeof fn.name === "string" ? fn.name.trim() : "";
+			if (name) {
+				return { functionCallingConfig: { mode: "ANY", allowedFunctionNames: [name] } };
+			}
+		}
+	}
+
+	return null;
+}
+
+export class GeminiApi extends CommonApi<GeminiChatMessage, GeminiGenerateContentRequest> {
+	constructor(private readonly toolCallMetaByCallId?: Map<string, GeminiToolCallMeta>) {
+		super();
+	}
+
+	convertMessages(
+		messages: readonly LanguageModelChatRequestMessage[],
+		_modelConfig: { includeReasoningInRequest: boolean }
+	): GeminiChatMessage[] {
+		const out: GeminiChatMessage[] = [];
+		const toolNameByCallId = new Map<string, string>();
+
+		const extractMessageParts = (m: LanguageModelChatRequestMessage) => {
+			const textParts: string[] = [];
+			const imageParts: vscode.LanguageModelDataPart[] = [];
+			const toolCalls: Array<{ callId: string; name: string; args: Record<string, unknown> }> = [];
+			const toolResults: Array<{ callId: string; outputText: string }> = [];
+
+			for (const part of m.content ?? []) {
+				if (part instanceof vscode.LanguageModelTextPart) {
+					textParts.push(part.value);
+				} else if (part instanceof vscode.LanguageModelDataPart && isImageMimeType(part.mimeType)) {
+					imageParts.push(part);
+				} else if (part instanceof vscode.LanguageModelToolCallPart) {
+					const callId = part.callId || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+					const args = part.input && typeof part.input === "object" ? (part.input as Record<string, unknown>) : {};
+					toolCalls.push({ callId, name: part.name, args });
+				} else if (isToolResultPart(part)) {
+					const callId = (part as { callId?: string }).callId ?? "";
+					const outputText = collectToolResultText(part as { content?: ReadonlyArray<unknown> });
+					toolResults.push({ callId, outputText });
+				}
+			}
+
+			return { text: textParts.join("").trim(), imageParts, toolCalls, toolResults };
+		};
+
+		const toolResultToFunctionResponsePart = (callId: string, outputText: string, fallbackName = ""): GeminiPart | null => {
+			if (!callId) {
+				return null;
+			}
+			const meta = this.toolCallMetaByCallId?.get(callId);
+			const name = toolNameByCallId.get(callId) ?? meta?.name ?? fallbackName;
+			if (!name) {
+				return null;
+			}
+
+			const parsed = tryParseJSONObject(outputText);
+			const responseValue: Record<string, unknown> = parsed.ok ? parsed.value : { output: outputText };
+			return { functionResponse: { name, response: responseValue } };
+		};
+
+		const isToolResultOnly = (extracted: {
+			text: string;
+			imageParts: vscode.LanguageModelDataPart[];
+			toolCalls: Array<unknown>;
+			toolResults: Array<unknown>;
+		}): boolean => {
+			return Boolean(
+				extracted.toolResults.length > 0 &&
+					!extracted.text &&
+					extracted.imageParts.length === 0 &&
+					extracted.toolCalls.length === 0
+			);
+		};
+
+		for (let i = 0; i < messages.length; i++) {
+			const m = messages[i];
+			const role = mapRole(m);
+			const extracted = extractMessageParts(m);
+
+			// Best-effort: group consecutive tool results into a single user turn.
+			if (isToolResultOnly(extracted)) {
+				const respParts: GeminiPart[] = [];
+				let j = i;
+				while (j < messages.length) {
+					const ex2 = extractMessageParts(messages[j]);
+					if (!isToolResultOnly(ex2)) {
+						break;
+					}
+					for (const tr of ex2.toolResults) {
+						const part = toolResultToFunctionResponsePart(tr.callId, tr.outputText);
+						if (part) {
+							respParts.push(part);
+						}
+					}
+					j++;
+				}
+				if (respParts.length > 0) {
+					out.push({ role: "user", parts: respParts });
+				}
+				i = j - 1;
+				continue;
+			}
+
+			if (role === "system") {
+				if (extracted.text) {
+					out.push({ role: "system", parts: [{ text: extracted.text }] });
+				}
+				continue;
+			}
+
+			if (role === "user") {
+				const parts: GeminiPart[] = [];
+				if (extracted.text) {
+					parts.push({ text: extracted.text });
+				}
+				for (const img of extracted.imageParts) {
+					const data = Buffer.from(img.data).toString("base64");
+					parts.push({ inlineData: { mimeType: img.mimeType, data } });
+				}
+				if (parts.length > 0) {
+					out.push({ role: "user", parts });
+				}
+				continue;
+			}
+
+			// assistant -> Gemini "model"
+			const parts: GeminiPart[] = [];
+			if (extracted.text) {
+				parts.push({ text: extracted.text });
+			}
+
+			const callOrder: Array<{ callId: string; name: string }> = [];
+			for (const tc of extracted.toolCalls) {
+				const callId = tc.callId;
+				const name = tc.name;
+				toolNameByCallId.set(callId, name);
+				callOrder.push({ callId, name });
+
+				const fcPart: Record<string, unknown> = {
+					functionCall: { name, args: tc.args },
+				};
+				const meta = this.toolCallMetaByCallId?.get(callId);
+				if (meta?.thoughtSignature) {
+					fcPart.thoughtSignature = meta.thoughtSignature;
+				}
+				if (meta?.thought) {
+					fcPart.thought = meta.thought;
+				}
+				parts.push(fcPart as GeminiPart);
+			}
+
+			if (parts.length > 0) {
+				out.push({ role: "model", parts });
+			}
+
+			// Gemini requires that tool responses are provided as a single "user" turn
+			// containing the same number of functionResponse parts as the preceding model's functionCall parts.
+			if (callOrder.length > 0) {
+				const responsesByCallId = new Map<string, GeminiPart>();
+				let j = i + 1;
+				while (j < messages.length) {
+					const ex2 = extractMessageParts(messages[j]);
+					if (!isToolResultOnly(ex2)) {
+						break;
+					}
+					for (const tr of ex2.toolResults) {
+						const part = toolResultToFunctionResponsePart(tr.callId, tr.outputText);
+						if (part) {
+							responsesByCallId.set(tr.callId, part);
+						}
+					}
+					j++;
+				}
+
+				if (responsesByCallId.size > 0) {
+					const respParts: GeminiPart[] = [];
+					for (const c of callOrder) {
+						const found = responsesByCallId.get(c.callId);
+						if (found) {
+							respParts.push(found);
+						} else {
+							respParts.push({ functionResponse: { name: c.name, response: { output: "" } } });
+						}
+					}
+					out.push({ role: "user", parts: respParts });
+					i = j - 1;
+				}
+			}
+		}
+
+		return out;
+	}
+
+	prepareRequestBody(
+		rb: GeminiGenerateContentRequest,
+		um: HFModelItem | undefined,
+		options: ProvideLanguageModelChatResponseOptions
+	): GeminiGenerateContentRequest {
+		const generationConfig: Record<string, unknown> = {
+			...(rb.generationConfig && typeof rb.generationConfig === "object" ? (rb.generationConfig as Record<string, unknown>) : {}),
+		};
+
+		// temperature
+		const oTemperature = options.modelOptions?.temperature ?? 0;
+		const temperature = um?.temperature ?? oTemperature;
+		generationConfig.temperature = temperature;
+		if (um && um.temperature === null) {
+			delete generationConfig.temperature;
+		}
+
+		// topP/topK
+		if (um?.top_p !== undefined && um.top_p !== null) {
+			generationConfig.topP = um.top_p;
+		}
+		if (um?.top_k !== undefined && um.top_k !== null) {
+			generationConfig.topK = um.top_k;
+		}
+
+		// maxOutputTokens
+		const maxOutput =
+			um?.max_completion_tokens !== undefined ? um.max_completion_tokens : um?.max_tokens !== undefined ? um.max_tokens : undefined;
+		if (maxOutput !== undefined) {
+			generationConfig.maxOutputTokens = maxOutput;
+		}
+
+		// stop sequences
+		if (options.modelOptions) {
+			const mo = options.modelOptions as Record<string, unknown>;
+			if (typeof mo.stop === "string" && mo.stop) {
+				generationConfig.stopSequences = [mo.stop];
+			} else if (Array.isArray(mo.stop)) {
+				generationConfig.stopSequences = mo.stop.filter((s) => typeof s === "string" && s);
+			}
+		}
+
+		// penalties
+		if (um?.presence_penalty !== undefined) {
+			generationConfig.presencePenalty = um.presence_penalty;
+		}
+		if (um?.frequency_penalty !== undefined) {
+			generationConfig.frequencyPenalty = um.frequency_penalty;
+		}
+
+		if (Object.keys(generationConfig).length > 0) {
+			rb.generationConfig = generationConfig;
+		}
+
+		// tools/toolConfig (from VS Code tools + toolMode)
+		const toolConfig = convertToolsToOpenAI(options);
+		if (toolConfig.tools && toolConfig.tools.length > 0) {
+			const decls = openaiToolsToGeminiFunctionDeclarations(toolConfig.tools);
+			if (decls.length > 0) {
+				rb.tools = [{ functionDeclarations: decls }];
+				const tc = openaiToolChoiceToGeminiToolConfig(toolConfig.tool_choice);
+				if (tc) {
+					rb.toolConfig = tc;
+				}
+			}
+		}
+
+		// extra parameters
+		if (um?.extra && typeof um.extra === "object") {
+			for (const [key, value] of Object.entries(um.extra)) {
+				if (value !== undefined) {
+					rb[key] = value;
+				}
+			}
+		}
+
+		return rb;
+	}
+
+	async processStreamingResponse(
+		responseBody: ReadableStream<Uint8Array>,
+		progress: Progress<LanguageModelResponsePart2>,
+		token: CancellationToken
+	): Promise<void> {
+		const reader = responseBody.getReader();
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		let textSoFar = "";
+		const toolCallKeyToId = new Map<string, string>();
+		let pendingThought = "";
+		let pendingThoughtSignature = "";
+
+		try {
+			while (true) {
+				if (token.isCancellationRequested) {
+					break;
+				}
+
+				const { done, value } = await reader.read();
+				if (done) {
+					break;
+				}
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() || "";
+
+				for (const line of lines) {
+					if (!line.startsWith("data:")) {
+						continue;
+					}
+					const data = line.slice(5).trim();
+					if (!data || data === "[DONE]") {
+						continue;
+					}
+
+					let payload: GeminiGenerateContentResponse | null = null;
+					try {
+						payload = JSON.parse(data) as GeminiGenerateContentResponse;
+					} catch {
+						continue;
+					}
+					if (!payload) {
+						continue;
+					}
+
+					const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+					const cand = candidates.length > 0 ? candidates[0] : null;
+					const parts = Array.isArray(cand?.content?.parts) ? cand?.content?.parts : [];
+
+					for (const p of parts) {
+						const fc = p?.functionCall;
+						if (!fc || typeof fc !== "object") {
+							// Standalone thought (2025 API: thought comes in separate part before functionCall)
+							const maybeThought = p && typeof p === "object" ? (p as unknown as Record<string, unknown>) : null;
+							const thought = maybeThought && typeof maybeThought.thought === "string" ? maybeThought.thought : "";
+							const thoughtSigRaw =
+								maybeThought && typeof maybeThought.thoughtSignature === "string"
+									? maybeThought.thoughtSignature
+									: maybeThought && typeof maybeThought.thought_signature === "string"
+										? maybeThought.thought_signature
+										: "";
+							if (thought) {
+								pendingThought = thought;
+							}
+							if (thoughtSigRaw) {
+								pendingThoughtSignature = thoughtSigRaw;
+							}
+							continue;
+						}
+						const name = typeof (fc as { name?: unknown }).name === "string" ? String((fc as { name: string }).name).trim() : "";
+						if (!name) {
+							continue;
+						}
+						const argsRaw = (fc as { args?: unknown }).args;
+						const argsObj = argsRaw && typeof argsRaw === "object" && !Array.isArray(argsRaw) ? (argsRaw as Record<string, unknown>) : {};
+						const key = `${name}\n${JSON.stringify(argsObj)}`;
+
+						const pObj = p && typeof p === "object" ? (p as unknown as Record<string, unknown>) : null;
+						const fcObj = fc && typeof fc === "object" ? (fc as unknown as Record<string, unknown>) : null;
+						const thoughtSigRaw =
+							(pObj && typeof pObj.thoughtSignature === "string" ? pObj.thoughtSignature : "") ||
+							(pObj && typeof pObj.thought_signature === "string" ? pObj.thought_signature : "") ||
+							(fcObj && typeof fcObj.thoughtSignature === "string" ? fcObj.thoughtSignature : "") ||
+							(fcObj && typeof fcObj.thought_signature === "string" ? fcObj.thought_signature : "") ||
+							pendingThoughtSignature;
+						const thoughtRaw =
+							(pObj && typeof pObj.thought === "string" ? pObj.thought : "") ||
+							(fcObj && typeof fcObj.thought === "string" ? fcObj.thought : "") ||
+							pendingThought;
+
+						// Reset pending after consuming
+						pendingThought = "";
+						pendingThoughtSignature = "";
+
+						let id = toolCallKeyToId.get(key);
+						const isNew = !id;
+						if (!id) {
+							id = `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+							toolCallKeyToId.set(key, id);
+						}
+
+						// Cache thoughtSignature/thought for Gemini thinking models (2025 API requirement)
+						if (this.toolCallMetaByCallId) {
+							this.toolCallMetaByCallId.set(id, {
+								name,
+								thoughtSignature: thoughtSigRaw || undefined,
+								thought: thoughtRaw || undefined,
+								createdAt: Date.now(),
+							});
+							// Basic pruning to avoid unbounded growth.
+							const maxEntries = 2000;
+							const pruneTo = 1500;
+							if (this.toolCallMetaByCallId.size > maxEntries) {
+								while (this.toolCallMetaByCallId.size > pruneTo) {
+									const first = this.toolCallMetaByCallId.keys().next().value as string | undefined;
+									if (!first) {
+										break;
+									}
+									this.toolCallMetaByCallId.delete(first);
+								}
+							}
+						}
+
+						if (isNew) {
+							this.reportEndThinking(progress);
+							if (!this._emittedBeginToolCallsHint && this._hasEmittedAssistantText) {
+								progress.report(new vscode.LanguageModelTextPart(" "));
+								this._emittedBeginToolCallsHint = true;
+							}
+							progress.report(new vscode.LanguageModelToolCallPart(id, name, argsObj));
+						}
+					}
+
+					const textJoined = parts
+						.map((p) => (p && typeof p === "object" && typeof (p as GeminiPart).text === "string" ? String((p as GeminiPart).text) : ""))
+						.filter(Boolean)
+						.join("");
+
+					if (textJoined) {
+						let delta = "";
+						if (textJoined.startsWith(textSoFar)) {
+							delta = textJoined.slice(textSoFar.length);
+							textSoFar = textJoined;
+						} else if (textSoFar.startsWith(textJoined)) {
+							delta = "";
+						} else {
+							delta = textJoined;
+							textSoFar += textJoined;
+						}
+
+						if (delta) {
+							this.reportEndThinking(progress);
+							progress.report(new vscode.LanguageModelTextPart(delta));
+							this._hasEmittedAssistantText = true;
+						}
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+			this.reportEndThinking(progress);
+		}
+	}
+}

--- a/src/gemini/geminiTypes.ts
+++ b/src/gemini/geminiTypes.ts
@@ -1,0 +1,83 @@
+export interface GeminiInlineData {
+	mimeType: string;
+	data: string;
+}
+
+export interface GeminiFunctionCall {
+	name: string;
+	args?: Record<string, unknown>;
+}
+
+export interface GeminiFunctionResponse {
+	name: string;
+	response: Record<string, unknown>;
+}
+
+export interface GeminiPart {
+	text?: string;
+	inlineData?: GeminiInlineData;
+	fileData?: { fileUri: string; mimeType?: string };
+	functionCall?: GeminiFunctionCall;
+	functionResponse?: GeminiFunctionResponse;
+	// 2025+ thinking fields (may appear in streaming responses)
+	thought?: string;
+	thought_signature?: string;
+	thoughtSignature?: string;
+}
+
+export interface GeminiContent {
+	role: "user" | "model";
+	parts: GeminiPart[];
+}
+
+export interface GeminiSystemInstruction {
+	role: "user";
+	parts: Array<{ text: string }>;
+}
+
+export interface GeminiFunctionDeclaration {
+	name: string;
+	description?: string;
+	parameters?: Record<string, unknown>;
+}
+
+export interface GeminiTool {
+	functionDeclarations: GeminiFunctionDeclaration[];
+}
+
+export interface GeminiToolConfig {
+	functionCallingConfig: {
+		mode: "AUTO" | "ANY" | "NONE";
+		allowedFunctionNames?: string[];
+	};
+}
+
+export interface GeminiGenerationConfig {
+	temperature?: number;
+	topP?: number;
+	topK?: number;
+	maxOutputTokens?: number;
+	stopSequences?: string[];
+	presencePenalty?: number;
+	frequencyPenalty?: number;
+}
+
+export interface GeminiGenerateContentRequest {
+	contents: GeminiContent[];
+	systemInstruction?: GeminiSystemInstruction;
+	generationConfig?: GeminiGenerationConfig;
+	tools?: GeminiTool[];
+	toolConfig?: GeminiToolConfig;
+	[key: string]: unknown;
+}
+
+export interface GeminiGenerateContentResponse {
+	candidates?: Array<{
+		content?: { role?: string; parts?: GeminiPart[] };
+		finishReason?: string;
+		finish_reason?: string;
+	}>;
+	usageMetadata?: unknown;
+	[key: string]: unknown;
+}
+

--- a/src/ollama/ollamaApi.ts
+++ b/src/ollama/ollamaApi.ts
@@ -15,7 +15,7 @@ import { isToolResultPart, collectToolResultText, convertToolsToOpenAI, mapRole 
 
 import { CommonApi } from "../commonApi";
 
-export class OllamaApi extends CommonApi {
+export class OllamaApi extends CommonApi<OllamaMessage, OllamaRequestBody> {
 	constructor() {
 		super();
 	}

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -29,7 +29,7 @@ import {
 
 import { CommonApi } from "../commonApi";
 
-export class OpenaiApi extends CommonApi {
+export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unknown>> {
 	constructor() {
 		super();
 	}

--- a/src/openai/openaiResponsesApi.ts
+++ b/src/openai/openaiResponsesApi.ts
@@ -1,0 +1,513 @@
+import * as vscode from "vscode";
+import {
+	CancellationToken,
+	LanguageModelChatRequestMessage,
+	ProvideLanguageModelChatResponseOptions,
+	LanguageModelResponsePart2,
+	Progress,
+} from "vscode";
+
+import type { HFModelItem } from "../types";
+import type { OpenAIToolCall } from "./openaiTypes";
+
+import {
+	isImageMimeType,
+	createDataUrl,
+	isToolResultPart,
+	collectToolResultText,
+	convertToolsToOpenAIResponses,
+	mapRole,
+} from "../utils";
+
+import { CommonApi } from "../commonApi";
+
+export interface ResponsesInputMessage {
+	role: "user" | "assistant" | "system";
+	content: ResponsesContentPart[];
+}
+
+export interface ResponsesContentPart {
+	type: "input_text" | "input_image" | "output_text";
+	text?: string;
+	image_url?: string;
+}
+
+export interface ResponsesFunctionCall {
+	type: "function_call";
+	id?: string;
+	call_id: string;
+	name: string;
+	arguments: string;
+}
+
+export interface ResponsesFunctionCallOutput {
+	type: "function_call_output";
+	call_id: string;
+	output: string;
+}
+
+export type ResponsesInputItem = ResponsesInputMessage | ResponsesFunctionCall | ResponsesFunctionCallOutput;
+
+export class OpenaiResponsesApi extends CommonApi<ResponsesInputItem, Record<string, unknown>> {
+	constructor() {
+		super();
+	}
+
+	convertMessages(
+		messages: readonly LanguageModelChatRequestMessage[],
+		modelConfig: { includeReasoningInRequest: boolean }
+	): ResponsesInputItem[] {
+		const out: ResponsesInputItem[] = [];
+
+		for (const m of messages) {
+			const role = mapRole(m);
+			const textParts: string[] = [];
+			const imageParts: vscode.LanguageModelDataPart[] = [];
+			const toolCalls: OpenAIToolCall[] = [];
+			const toolResults: { callId: string; content: string }[] = [];
+			const thinkingParts: string[] = [];
+
+			for (const part of m.content ?? []) {
+				if (part instanceof vscode.LanguageModelTextPart) {
+					textParts.push(part.value);
+				} else if (part instanceof vscode.LanguageModelDataPart && isImageMimeType(part.mimeType)) {
+					imageParts.push(part);
+				} else if (part instanceof vscode.LanguageModelToolCallPart) {
+					const id = part.callId || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+					let args = "{}";
+					try {
+						args = JSON.stringify(part.input ?? {});
+					} catch {
+						args = "{}";
+					}
+					toolCalls.push({ id, type: "function", function: { name: part.name, arguments: args } });
+				} else if (isToolResultPart(part)) {
+					const callId = (part as { callId?: string }).callId ?? "";
+					const content = collectToolResultText(part as { content?: ReadonlyArray<unknown> });
+					toolResults.push({ callId, content });
+				} else if (part instanceof vscode.LanguageModelThinkingPart && modelConfig.includeReasoningInRequest) {
+					const content = Array.isArray(part.value) ? part.value.join("") : part.value;
+					thinkingParts.push(content);
+				}
+			}
+
+			const joinedText = textParts.join("").trim();
+			const joinedThinking = thinkingParts.join("").trim();
+
+			// assistant message (optional)
+			if (role === "assistant") {
+				const assistantText = joinedText || joinedThinking;
+				if (assistantText) {
+					out.push({
+						role: "assistant",
+						content: [{ type: "output_text", text: assistantText }],
+					});
+				}
+
+				for (const tc of toolCalls) {
+					out.push({
+						type: "function_call",
+						id: `fc_${tc.id}`,
+						call_id: tc.id,
+						name: tc.function.name,
+						arguments: tc.function.arguments,
+					});
+				}
+			}
+
+			// tool outputs
+			for (const tr of toolResults) {
+				if (!tr.callId) {
+					continue;
+				}
+				out.push({
+					type: "function_call_output",
+					call_id: tr.callId,
+					output: tr.content || "",
+				});
+			}
+
+			// user message
+			if (role === "user") {
+				const contentArray: ResponsesContentPart[] = [];
+				if (joinedText) {
+					contentArray.push({ type: "input_text", text: joinedText });
+				}
+				for (const imagePart of imageParts) {
+					const dataUrl = createDataUrl(imagePart);
+					contentArray.push({ type: "input_image", image_url: dataUrl });
+				}
+				if (contentArray.length > 0) {
+					out.push({ role: "user", content: contentArray });
+				}
+			}
+
+			// system message (used to build `instructions` in request body)
+			if (role === "system" && joinedText) {
+				out.push({ role: "system", content: [{ type: "input_text", text: joinedText }] });
+			}
+		}
+		return out;
+	}
+
+	prepareRequestBody(
+		rb: Record<string, unknown>,
+		um: HFModelItem | undefined,
+		options: ProvideLanguageModelChatResponseOptions
+	): Record<string, unknown> {
+		// temperature
+		const oTemperature = options.modelOptions?.temperature ?? 0;
+		const temperature = um?.temperature ?? oTemperature;
+		rb.temperature = temperature;
+		if (um && um.temperature === null) {
+			delete rb.temperature;
+		}
+
+		// top_p
+		if (um?.top_p !== undefined && um.top_p !== null) {
+			rb.top_p = um.top_p;
+		}
+
+		// max_output_tokens
+		if (um?.max_completion_tokens !== undefined) {
+			rb.max_output_tokens = um.max_completion_tokens;
+		} else if (um?.max_tokens !== undefined) {
+			rb.max_output_tokens = um.max_tokens;
+		}
+
+		// OpenAI reasoning configuration
+		if (um?.reasoning_effort !== undefined) {
+			rb.reasoning = {
+				effort: um.reasoning_effort,
+			};
+		}
+
+		// stop
+		if (options.modelOptions) {
+			const mo = options.modelOptions as Record<string, unknown>;
+			if (typeof mo.stop === "string" || Array.isArray(mo.stop)) {
+				rb.stop = mo.stop;
+			}
+		}
+
+		// tools
+		const toolConfig = convertToolsToOpenAIResponses(options);
+		if (toolConfig.tools) {
+			rb.tools = toolConfig.tools;
+		}
+		if (toolConfig.tool_choice) {
+			rb.tool_choice = toolConfig.tool_choice;
+		}
+
+		// Process extra configuration parameters
+		if (um?.extra && typeof um.extra === "object") {
+			for (const [key, value] of Object.entries(um.extra)) {
+				if (value !== undefined) {
+					rb[key] = value;
+				}
+			}
+		}
+
+		return rb;
+	}
+
+	async processStreamingResponse(
+		responseBody: ReadableStream<Uint8Array>,
+		progress: Progress<LanguageModelResponsePart2>,
+		token: CancellationToken
+	): Promise<void> {
+		const reader = responseBody.getReader();
+		const decoder = new TextDecoder();
+		let buffer = "";
+
+		try {
+			while (true) {
+				if (token.isCancellationRequested) {
+					break;
+				}
+
+				const { done, value } = await reader.read();
+				if (done) {
+					break;
+				}
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() || "";
+
+				for (const line of lines) {
+					if (!line.startsWith("data:")) {
+						continue;
+					}
+					const data = line.slice(5).trim();
+					if (data === "[DONE]") {
+						await this.flushToolCallBuffers(progress, false);
+						continue;
+					}
+
+					try {
+						const parsed = JSON.parse(data) as Record<string, unknown>;
+						await this.processEvent(parsed, progress);
+					} catch {
+						// Silently ignore malformed SSE lines
+					}
+				}
+			}
+		} finally {
+			reader.releaseLock();
+			this.reportEndThinking(progress);
+		}
+	}
+
+	private async processEvent(event: Record<string, unknown>, progress: Progress<LanguageModelResponsePart2>): Promise<void> {
+		const eventType = typeof event.type === "string" ? event.type : "";
+		if (!eventType) {
+			return;
+		}
+
+		switch (eventType) {
+			case "response.output_text.delta":
+			case "response.refusal.delta": {
+				const delta = typeof event.delta === "string" ? event.delta : "";
+				if (!delta) {
+					return;
+				}
+				this.reportEndThinking(progress);
+				progress.report(new vscode.LanguageModelTextPart(delta));
+				this._hasEmittedAssistantText = true;
+				return;
+			}
+
+			case "response.output_text.done":
+			case "response.refusal.done": {
+				// Some gateways only emit a final "done" payload (no deltas).
+				const text = typeof event.text === "string" ? event.text : "";
+				if (!text || this._hasEmittedAssistantText) {
+					return;
+				}
+				this.reportEndThinking(progress);
+				progress.report(new vscode.LanguageModelTextPart(text));
+				this._hasEmittedAssistantText = true;
+				return;
+			}
+
+			case "response.reasoning.delta":
+			case "response.reasoning_summary.delta": {
+				const delta = typeof event.delta === "string" ? event.delta : "";
+				if (delta) {
+					this.bufferThinkingContent(delta, progress);
+				}
+				return;
+			}
+
+			case "response.function_call_arguments.delta":
+			case "response.function_call_arguments.done":
+			case "response.function_call.done": {
+				this.reportEndThinking(progress);
+
+				const callId = this.getCallIdFromEvent(event);
+				const name = typeof event.name === "string" ? event.name : "";
+				const chunk =
+					eventType === "response.function_call_arguments.delta"
+						? typeof event.delta === "string"
+							? event.delta
+							: ""
+						: typeof event.arguments === "string"
+							? event.arguments
+							: "";
+
+				if (!callId) {
+					return;
+				}
+
+				if (!this._emittedBeginToolCallsHint && this._hasEmittedAssistantText) {
+					progress.report(new vscode.LanguageModelTextPart(" "));
+					this._emittedBeginToolCallsHint = true;
+				}
+
+				const idx = this.getToolCallIndex(callId);
+				if (this._completedToolCallIndices.has(idx)) {
+					return;
+				}
+
+				const buf = this._toolCallBuffers.get(idx) ?? { args: "" };
+				buf.id = callId;
+				if (name) {
+					buf.name = name;
+				}
+
+				if (eventType === "response.function_call_arguments.delta" && chunk) {
+					buf.args += chunk;
+				} else if (chunk) {
+					// "done" events typically provide the full argument string.
+					buf.args = chunk;
+				}
+				this._toolCallBuffers.set(idx, buf);
+
+				await this.tryEmitBufferedToolCall(idx, progress);
+
+				if (eventType !== "response.function_call_arguments.delta") {
+					await this.flushToolCallBuffers(progress, true);
+				}
+				return;
+			}
+
+			case "response.output_item.added":
+			case "response.output_item.done": {
+				const item = event.item && typeof event.item === "object" ? (event.item as Record<string, unknown>) : null;
+				if (!item || item.type !== "function_call") {
+					return;
+				}
+				this.reportEndThinking(progress);
+
+				const callId = this.getCallIdFromEvent(item);
+				const name =
+					typeof item.name === "string"
+						? item.name
+						: item.function && typeof item.function === "object" && typeof (item.function as Record<string, unknown>).name === "string"
+							? String((item.function as Record<string, unknown>).name)
+							: "";
+				const args =
+					typeof item.arguments === "string"
+						? item.arguments
+						: item.function && typeof item.function === "object" && typeof (item.function as Record<string, unknown>).arguments === "string"
+							? String((item.function as Record<string, unknown>).arguments)
+							: "";
+
+				if (!callId) {
+					return;
+				}
+
+				if (!this._emittedBeginToolCallsHint && this._hasEmittedAssistantText) {
+					progress.report(new vscode.LanguageModelTextPart(" "));
+					this._emittedBeginToolCallsHint = true;
+				}
+
+				const idx = this.getToolCallIndex(callId);
+				if (this._completedToolCallIndices.has(idx)) {
+					return;
+				}
+
+				const buf = this._toolCallBuffers.get(idx) ?? { args: "" };
+				buf.id = callId;
+				if (name) {
+					buf.name = name;
+				}
+				if (args) {
+					buf.args = args;
+				}
+				this._toolCallBuffers.set(idx, buf);
+				await this.tryEmitBufferedToolCall(idx, progress);
+				return;
+			}
+
+			case "response.completed":
+			case "response.done": {
+				// Response complete (some gateways use `response.done`).
+				const responseObj =
+					event.response && typeof event.response === "object" ? (event.response as Record<string, unknown>) : null;
+
+				if (responseObj) {
+					if (!this._hasEmittedAssistantText) {
+						const text = this.extractOutputText(responseObj);
+						if (text) {
+							this.reportEndThinking(progress);
+							progress.report(new vscode.LanguageModelTextPart(text));
+							this._hasEmittedAssistantText = true;
+						}
+					}
+
+					for (const call of this.extractToolCalls(responseObj)) {
+						const idx = this.getToolCallIndex(call.callId);
+						if (this._completedToolCallIndices.has(idx)) {
+							continue;
+						}
+						const buf = this._toolCallBuffers.get(idx) ?? { args: "" };
+						buf.id = call.callId;
+						buf.name = call.name;
+						buf.args = call.args;
+						this._toolCallBuffers.set(idx, buf);
+						await this.tryEmitBufferedToolCall(idx, progress);
+					}
+				}
+
+				await this.flushToolCallBuffers(progress, true);
+				return;
+			}
+		}
+	}
+
+	private getCallIdFromEvent(event: Record<string, unknown>): string {
+		const callIdRaw = event.call_id ?? event.callId ?? event.id;
+		return typeof callIdRaw === "string" ? callIdRaw : "";
+	}
+
+	private extractOutputText(response: Record<string, unknown>): string {
+		const outputText = response.output_text;
+		if (typeof outputText === "string" && outputText.trim()) {
+			return outputText;
+		}
+
+		const output = Array.isArray(response.output) ? response.output : [];
+		const parts: string[] = [];
+		for (const item of output) {
+			if (!item || typeof item !== "object") {
+				continue;
+			}
+			const itemObj = item as Record<string, unknown>;
+			const content = Array.isArray(itemObj.content) ? itemObj.content : [];
+			for (const c of content) {
+				if (!c || typeof c !== "object") {
+					continue;
+				}
+				const cObj = c as Record<string, unknown>;
+				if (cObj.type !== "output_text") {
+					continue;
+				}
+				if (typeof cObj.text === "string" && cObj.text) {
+					parts.push(cObj.text);
+				}
+			}
+		}
+		return parts.join("");
+	}
+
+	private extractToolCalls(response: Record<string, unknown>): Array<{ callId: string; name: string; args: string }> {
+		const output = Array.isArray(response.output) ? response.output : [];
+		const out: Array<{ callId: string; name: string; args: string }> = [];
+
+		for (const item of output) {
+			if (!item || typeof item !== "object") {
+				continue;
+			}
+			const itemObj = item as Record<string, unknown>;
+			if (itemObj.type !== "function_call") {
+				continue;
+			}
+
+			const callId = this.getCallIdFromEvent(itemObj);
+			if (!callId) {
+				continue;
+			}
+
+			const name = typeof itemObj.name === "string" ? itemObj.name : "";
+			const args = typeof itemObj.arguments === "string" ? itemObj.arguments : "";
+			if (!name || !args) {
+				continue;
+			}
+			out.push({ callId, name, args });
+		}
+
+		return out;
+	}
+
+	private _toolCallIdToIndex = new Map<string, number>();
+	private _nextToolCallIndex = 0;
+
+	private getToolCallIndex(callId: string): number {
+		if (!this._toolCallIdToIndex.has(callId)) {
+			this._toolCallIdToIndex.set(callId, this._nextToolCallIndex++);
+		}
+		return this._toolCallIdToIndex.get(callId)!;
+	}
+}

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { CancellationToken, LanguageModelChatInformation } from "vscode";
 
 import type { HFModelItem, HFModelsResponse } from "./types";
+import { normalizeUserModels } from "./utils";
 
 const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_MAX_TOKENS = 4096;
@@ -20,7 +21,7 @@ export async function prepareLanguageModelChatInformation(
 ): Promise<LanguageModelChatInformation[]> {
 	// Check for user-configured models first
 	const config = vscode.workspace.getConfiguration();
-	const userModels = config.get<HFModelItem[]>("oaicopilot.models", []);
+	const userModels = normalizeUserModels(config.get<unknown>("oaicopilot.models", []));
 
 	let infos: LanguageModelChatInformation[];
 	if (userModels && userModels.length > 0) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -13,15 +13,18 @@ import type { HFModelItem } from "./types";
 
 import type { OllamaRequestBody } from "./ollama/ollamaTypes";
 
-import { parseModelId, createRetryConfig, executeWithRetry } from "./utils";
+import { parseModelId, createRetryConfig, executeWithRetry, normalizeUserModels } from "./utils";
 
 import { prepareLanguageModelChatInformation } from "./provideModel";
 import { prepareTokenCount } from "./provideToken";
 import { updateContextStatusBar } from "./statusBar";
 import { OllamaApi } from "./ollama/ollamaApi";
 import { OpenaiApi } from "./openai/openaiApi";
+import { OpenaiResponsesApi } from "./openai/openaiResponsesApi";
 import { AnthropicApi } from "./anthropic/anthropicApi";
 import { AnthropicRequestBody } from "./anthropic/anthropicTypes";
+import { GeminiApi, buildGeminiGenerateContentUrl, type GeminiToolCallMeta } from "./gemini/geminiApi";
+import type { GeminiGenerateContentRequest } from "./gemini/geminiTypes";
 
 /**
  * VS Code Chat provider backed by Hugging Face Inference Providers.
@@ -29,6 +32,8 @@ import { AnthropicRequestBody } from "./anthropic/anthropicTypes";
 export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	/** Track last request completion time for delay calculation. */
 	private _lastRequestTime: number | null = null;
+
+	private readonly _geminiToolCallMetaByCallId = new Map<string, GeminiToolCallMeta>();
 
 	/**
 	 * Create a provider using the given secret storage for the API key.
@@ -108,7 +113,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		try {
 			// get model config from user settings
 			const config = vscode.workspace.getConfiguration();
-			const userModels = config.get<HFModelItem[]>("oaicopilot.models", []);
+			const userModels = normalizeUserModels(config.get<unknown>("oaicopilot.models", []));
 
 			// 解析模型ID以处理配置ID
 			const parsedModelId = parseModelId(model.id);
@@ -189,8 +194,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				// console.debug("[OAI Compatible Model Provider] RequestBody:", JSON.stringify(ollamaRequestBody));
 
 				// send Ollama chat request with retry
+				const url = `${BASE_URL.replace(/\/+$/, "")}/api/chat`;
 				const response = await executeWithRetry(async () => {
-					const res = await fetch(`${BASE_URL.replace(/\/+$/, "")}/api/chat`, {
+					const res = await fetch(url, {
 						method: "POST",
 						headers: requestHeaders,
 						body: JSON.stringify(ollamaRequestBody),
@@ -199,7 +205,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					if (!res.ok) {
 						const errorText = await res.text();
 						console.error("[Ollama Provider] Ollama API error response", errorText);
-						throw new Error(`Ollama API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}`);
+						throw new Error(
+							`Ollama API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+						);
 					}
 
 					return res;
@@ -224,8 +232,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				// console.debug("[OAI Compatible Model Provider] RequestBody:", JSON.stringify(requestBody));
 
 				// send Anthropic chat request with retry
+				const url = `${BASE_URL.replace(/\/+$/, "")}/v1/messages`;
 				const response = await executeWithRetry(async () => {
-					const res = await fetch(`${BASE_URL.replace(/\/+$/, "")}/v1/messages`, {
+					const res = await fetch(url, {
 						method: "POST",
 						headers: requestHeaders,
 						body: JSON.stringify(requestBody),
@@ -235,7 +244,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 						const errorText = await res.text();
 						console.error("[Anthropic Provider] Anthropic API error response", errorText);
 						throw new Error(
-							`Anthropic API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}`
+							`Anthropic API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
 						);
 					}
 
@@ -246,6 +255,128 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					throw new Error("No response body from Anthropic API");
 				}
 				await anthropicApi.processStreamingResponse(response.body, trackingProgress, token);
+			} else if (apiMode === "openai-responses") {
+				// OpenAI Responses API mode
+				const openaiResponsesApi = new OpenaiResponsesApi();
+				const rawInput = openaiResponsesApi.convertMessages(messages, modelConfig);
+
+				const instructionsParts: string[] = [];
+				const input: unknown[] = [];
+				for (const item of rawInput) {
+					if (
+						item &&
+						typeof item === "object" &&
+						"role" in item &&
+						(item as { role?: unknown }).role === "system" &&
+						Array.isArray((item as { content?: unknown }).content)
+					) {
+						for (const part of (item as { content: unknown[] }).content) {
+							if (
+								part &&
+								typeof part === "object" &&
+								(part as { type?: unknown }).type === "input_text" &&
+								typeof (part as { text?: unknown }).text === "string" &&
+								(part as { text: string }).text.trim()
+							) {
+								instructionsParts.push((part as { text: string }).text);
+							}
+						}
+						continue;
+					}
+					input.push(item);
+				}
+
+				// requestBody
+				let requestBody: Record<string, unknown> = {
+					model: parsedModelId.baseId,
+					input,
+					stream: true,
+				};
+				if (instructionsParts.length > 0) {
+					requestBody.instructions = instructionsParts.join("\n");
+				}
+				requestBody = openaiResponsesApi.prepareRequestBody(requestBody, um, options);
+
+				// send Responses API request with retry
+				const url = `${BASE_URL.replace(/\/+$/, "")}/responses`;
+				const response = await executeWithRetry(async () => {
+					const res = await fetch(url, {
+						method: "POST",
+						headers: requestHeaders,
+						body: JSON.stringify(requestBody),
+					});
+
+					if (!res.ok) {
+						const errorText = await res.text();
+						console.error("[OAI Compatible Model Provider] Responses API error response", errorText);
+						throw new Error(
+							`Responses API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+						);
+					}
+
+					return res;
+				}, retryConfig);
+
+				if (!response.body) {
+					throw new Error("No response body from Responses API");
+				}
+				await openaiResponsesApi.processStreamingResponse(response.body, trackingProgress, token);
+			} else if (apiMode === "gemini") {
+				// Gemini native API mode
+				const geminiApi = new GeminiApi(this._geminiToolCallMetaByCallId);
+				const geminiMessages = geminiApi.convertMessages(messages, modelConfig);
+
+				const systemParts: string[] = [];
+				const contents: GeminiGenerateContentRequest["contents"] = [];
+				for (const msg of geminiMessages) {
+					if (msg.role === "system") {
+						const text = msg.parts
+							.map((p) => (p && typeof p === "object" && typeof (p as { text?: unknown }).text === "string" ? String((p as { text: string }).text) : ""))
+							.join("")
+							.trim();
+						if (text) {
+							systemParts.push(text);
+						}
+						continue;
+					}
+					contents.push({ role: msg.role, parts: msg.parts });
+				}
+
+				let requestBody: GeminiGenerateContentRequest = {
+					contents,
+				};
+				if (systemParts.length > 0) {
+					requestBody.systemInstruction = { role: "user", parts: [{ text: systemParts.join("\n") }] };
+				}
+				requestBody = geminiApi.prepareRequestBody(requestBody, um, options);
+
+				const url = buildGeminiGenerateContentUrl(BASE_URL, parsedModelId.baseId, true);
+				if (!url) {
+					throw new Error("Invalid Gemini base URL configuration.");
+				}
+
+				const response = await executeWithRetry(async () => {
+					const res = await fetch(url, {
+						method: "POST",
+						headers: requestHeaders,
+						body: JSON.stringify(requestBody),
+					});
+
+					if (!res.ok) {
+						const errorText = await res.text();
+						console.error("[Gemini Provider] Gemini API error response", errorText);
+						throw new Error(
+							`Gemini API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+						);
+					}
+
+					return res;
+				}, retryConfig);
+
+				if (!response.body) {
+					throw new Error("No response body from Gemini API");
+				}
+				await geminiApi.processStreamingResponse(response.body, trackingProgress, token);
 			} else {
 				// OpenAI compatible API mode (default)
 				const openaiApi = new OpenaiApi();
@@ -262,8 +393,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				// console.debug("[OAI Compatible Model Provider] RequestBody:", JSON.stringify(requestBody));
 
 				// send chat request with retry
+				const url = `${BASE_URL.replace(/\/+$/, "")}/chat/completions`;
 				const response = await executeWithRetry(async () => {
-					const res = await fetch(`${BASE_URL.replace(/\/+$/, "")}/chat/completions`, {
+					const res = await fetch(url, {
 						method: "POST",
 						headers: requestHeaders,
 						body: JSON.stringify(requestBody),
@@ -273,7 +405,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 						const errorText = await res.text();
 						console.error("[OAI Compatible Model Provider] OAI Compatible API error response", errorText);
 						throw new Error(
-							`OAI Compatible API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}`
+							`OAI Compatible API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
 						);
 					}
 
@@ -315,6 +447,20 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			"User-Agent": this.userAgent,
 		};
 
+		if (apiMode === "anthropic") {
+			// Match Claude Code CLI / official Anthropic API requirements.
+			headers["anthropic-version"] = "2023-06-01";
+			headers["Accept"] = "text/event-stream";
+		}
+		if (apiMode === "openai-responses") {
+			headers["openai-beta"] = "responses=v1";
+			headers["Accept"] = "text/event-stream";
+		}
+		if (apiMode === "gemini") {
+			headers["x-goog-api-key"] = apiKey;
+			headers["Accept"] = "text/event-stream";
+		}
+
 		// Provider-specific header formats
 		if (apiMode === "anthropic") {
 			headers["x-api-key"] = apiKey;
@@ -341,7 +487,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 		// Try to get provider-specific API key first
 		let apiKey: string | undefined;
 		if (provider && provider.trim() !== "") {
-			const normalizedProvider = provider.toLowerCase();
+			const normalizedProvider = provider.trim().toLowerCase();
 			const providerKey = `oaicopilot.apiKey.${normalizedProvider}`;
 			apiKey = await this.secrets.get(providerKey);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,8 @@ export interface HFModelItem {
 	include_reasoning_in_request?: boolean;
 
 	/**
-	 * API mode: "openai" for OpenAI-compatible API, "ollama" for Ollama native API.
+	 * API mode: "openai" for OpenAI Chat Completions, "openai-responses" for OpenAI Responses,
+	 * "ollama" for Ollama native API, "anthropic" for Anthropic Messages, "gemini" for Gemini native API.
 	 * Default is "openai".
 	 */
 	apiMode?: HFApiMode;
@@ -133,4 +134,4 @@ export interface RetryConfig {
 }
 
 /** Supports API mode. */
-export type HFApiMode = "openai" | "ollama" | "anthropic";
+export type HFApiMode = "openai" | "openai-responses" | "ollama" | "anthropic" | "gemini";


### PR DESCRIPTION
- Add apiMode: openai-responses streaming /responses support

- Add apiMode: gemini native streaming and preserve thoughtSignature for tool calls

- Accept provider/provide as aliases of owned_by in oaicopilot.models

- Improve Anthropic headers and include request URL in errors for relay debugging