### PR TITLE
feat(thinking): show reasoning summaries in Copilot (OpenAI Responses + Gemini)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The `extra` field allows you to add arbitrary parameters to the API request body
 
 ### How it works
 - Parameters in `extra` are merged directly into the request body
-- Works with all API modes (`openai`, `ollama`, `anthropic`)
+- Works with all API modes (`openai`, `openai-responses`, `ollama`, `anthropic`, `gemini`)
 - Values can be any valid JSON type (string, number, boolean, object, array)
 
 ### Common use cases
@@ -325,6 +325,46 @@ The `extra` field allows you to add arbitrary parameters to the API request body
         }
     }
 ]
+```
+
+### Show thinking in Copilot
+These are provider-specific parameters that can make Copilot show a **Thinking** block (if the provider/model supports it).
+
+#### OpenAI Responses
+Use `apiMode: "openai-responses"` and set the reasoning summary mode:
+
+```json
+{
+  "id": "gpt-4o-mini",
+  "owned_by": "openai",
+  "baseUrl": "https://api.openai.com/v1",
+  "apiMode": "openai-responses",
+  "reasoning_effort": "high",
+  "extra": {
+    "reasoning": {
+      "summary": "detailed"
+    }
+  }
+}
+```
+
+#### Gemini
+Use `apiMode: "gemini"` and enable thought summaries:
+
+```json
+{
+  "id": "gemini-3-flash-preview",
+  "owned_by": "gemini",
+  "baseUrl": "https://generativelanguage.googleapis.com",
+  "apiMode": "gemini",
+  "extra": {
+    "generationConfig": {
+      "thinkingConfig": {
+        "includeThoughts": true
+      }
+    }
+  }
+}
 ```
 
 ### Important Notes

--- a/src/gemini/geminiTypes.ts
+++ b/src/gemini/geminiTypes.ts
@@ -20,7 +20,7 @@ export interface GeminiPart {
 	functionCall?: GeminiFunctionCall;
 	functionResponse?: GeminiFunctionResponse;
 	// 2025+ thinking fields (may appear in streaming responses)
-	thought?: string;
+	thought?: boolean | string;
 	thought_signature?: string;
 	thoughtSignature?: string;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -459,6 +459,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			headers["Authorization"] = `Bearer ${apiKey}`;
 		} else if (apiMode === "gemini") {
 			headers["x-goog-api-key"] = apiKey;
+			headers["Accept"] = "text/event-stream";
 		} else {
 			headers["Authorization"] = `Bearer ${apiKey}`;
 		}


### PR DESCRIPTION
 - Adds Copilot “Thinking” support for OpenAI Responses by mapping reasoning/summary SSE events (e.g. response.reasoning_text.delta,
    response.reasoning_summary_text.delta) into LanguageModelThinkingPart.
  - Fixes request-body composition for Responses: deep-merge reasoning so extra.reasoning doesn’t clobber reasoning_effort, and filters config values like detailed/concise
    from being displayed as thinking text.
  - Improves Gemini thinking: treats thought: true parts as thinking (and avoids leaking them into final output text).
  - Fixes Gemini tool schema compatibility by stripping unsupported JSON Schema keys (exclusiveMinimum/exclusiveMaximum) and ensures SSE streaming via Accept: text/event-
    stream.
  - Docs: adds configuration examples for enabling thinking:
      - OpenAI Responses: extra.reasoning.summary
      - Gemini: extra.generationConfig.thinkingConfig.includeThoughts

  Tested

  - npm run compile
  - npm run build