### PR TITLE
Programmatic apikey

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "An extension that integrates OpenAI/Ollama/Anthropic/Gemini API Providers into GitHub Copilot Chat",
 	"icon": "assets/logo.png",
 	"oaicopilotConfig": {
-		"allowProgrammaticApiKey": true
+		"allowProgrammaticApiKey": false
 	},
 	"keywords": [
 		"ai",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"displayName": "OAI Compatible Provider for Copilot",
 	"description": "An extension that integrates OpenAI/Ollama/Anthropic/Gemini API Providers into GitHub Copilot Chat",
 	"icon": "assets/logo.png",
+	"oaicopilotConfig": {
+		"allowProgrammaticApiKey": true
+	},
 	"keywords": [
 		"ai",
 		"chat",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import { ConfigViewPanel } from "./views/configView";
 import { normalizeUserModels } from "./utils";
 import { abortCommitGeneration, generateCommitMsg } from "./gitCommit/commitMessageGenerator";
 
+const ALLOW_PROGRAMMATIC_API_KEY = true;
+
 export function activate(context: vscode.ExtensionContext) {
 	const tokenCountStatusBarItem: vscode.StatusBarItem = initStatusBar(context);
 	const provider = new HuggingFaceChatModelProvider(context.secrets, tokenCountStatusBarItem);
@@ -14,7 +16,12 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Management command to configure API key
 	context.subscriptions.push(
-		vscode.commands.registerCommand("oaicopilot.setApikey", async () => {
+		vscode.commands.registerCommand("oaicopilot.setApikey", async (key?: string) => {
+			if (ALLOW_PROGRAMMATIC_API_KEY && key !== undefined) {
+				await context.secrets.store("oaicopilot.apiKey", key.trim());
+				return;
+			}
+
 			const existing = await context.secrets.get("oaicopilot.apiKey");
 			const apiKey = await vscode.window.showInputBox({
 				title: "OAI Compatible Provider API Key",
@@ -38,7 +45,42 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Management command to configure provider-specific API keys
 	context.subscriptions.push(
-		vscode.commands.registerCommand("oaicopilot.setProviderApikey", async () => {
+		vscode.commands.registerCommand("oaicopilot.setProviderApikey", async (key?: string, prov?: string) => {
+			if (ALLOW_PROGRAMMATIC_API_KEY && key !== undefined) {
+				let provider = prov;
+				if (!provider) {
+					// Get provider list from configuration for suggestions
+					const config = vscode.workspace.getConfiguration();
+					const userModels = normalizeUserModels(config.get<HFModelItem[]>("oaicopilot.models", []));
+					const providers = Array.from(
+						new Set(userModels.map((m) => m.owned_by.toLowerCase()).filter((p) => p && p.trim() !== ""))
+					).sort();
+
+					if (providers.length > 0) {
+						const selected = await vscode.window.showQuickPick(providers, {
+							title: "Select Provider",
+							placeHolder: "Select a provider for the API key",
+						});
+						if (!selected) {
+							return; // user canceled
+						}
+						provider = selected;
+					} else {
+						const entered = await vscode.window.showInputBox({
+							title: "Enter Provider Name",
+							prompt: "Enter the provider name (will be converted to lowercase)",
+							ignoreFocusOut: true,
+						});
+						if (!entered || !entered.trim()) {
+							return; // user canceled
+						}
+						provider = entered.trim();
+					}
+				}
+				await context.secrets.store(`oaicopilot.apiKey.${provider.toLowerCase()}`, key.trim());
+				return;
+			}
+
 			// Get provider list from configuration
 			const config = vscode.workspace.getConfiguration();
 			const userModels = normalizeUserModels(config.get<HFModelItem[]>("oaicopilot.models", []));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,20 @@ import { ConfigViewPanel } from "./views/configView";
 import { normalizeUserModels } from "./utils";
 import { abortCommitGeneration, generateCommitMsg } from "./gitCommit/commitMessageGenerator";
 
-const ALLOW_PROGRAMMATIC_API_KEY = true;
+interface OaicopilotConfig {
+	allowProgrammaticApiKey?: boolean;
+}
+
+function getExtensionConfig(): OaicopilotConfig {
+	const extension = vscode.extensions.getExtension("johnny-zhao.oai-compatible-copilot");
+	const packageJson = extension?.packageJSON;
+	return packageJson?.oaicopilotConfig ?? {};
+}
 
 export function activate(context: vscode.ExtensionContext) {
+	const extensionConfig = getExtensionConfig();
+	const ALLOW_PROGRAMMATIC_API_KEY = extensionConfig.allowProgrammaticApiKey ?? false;
+
 	const tokenCountStatusBarItem: vscode.StatusBarItem = initStatusBar(context);
 	const provider = new HuggingFaceChatModelProvider(context.secrets, tokenCountStatusBarItem);
 	// Register the Hugging Face provider under the vendor id used in package.json


### PR DESCRIPTION

## Implemented changes:

1. **Added `oaicopilotConfig.allowProgrammaticApiKey` in package.json**
   - Default: `false` (can be changed to `true` before building)
   - Not exposed in VS Code settings UI — only changeable by editing package.json

2. **Commands now support programmatic API key setting:**
   - `oaicopilot.setApikey(key)` — sets global API key directly
   - `oaicopilot.setProviderApikey(key, provider)` — sets provider-specific key
   - `oaicopilot.setProviderApikey(key)` — prompts for provider selection if not provided

3. **Example usage from another extension:**
   ```typescript
   // Set global API key
   vscode.commands.executeCommand('oaicopilot.setApikey', 'sk-xxx');
   
   // Set provider-specific API key
   vscode.commands.executeCommand('oaicopilot.setProviderApikey', 'sk-xxx', 'openai');
   ```

**Security:** The flag is code-level only — users cannot enable it through settings, only by rebuilding the VSIX.
