### PR TITLE
fix: max_completion_tokens takes precedence over max_tokens in OpenaiApi

### DIFF
--- a/assets/configView/configView.html
+++ b/assets/configView/configView.html
@@ -205,7 +205,7 @@
 						</div>
 						<div class="field">
 							<label for="modelMaxCompletionTokens">Max Completion Tokens</label>
-							<div class="field-description">Maximum number of tokens to generate (OpenAI new standard parameter).</div>
+							<div class="field-description">Maximum output tokens (OpenAI new standard - takes precedence over Max Tokens if both are set).</div>
 							<input id="modelMaxCompletionTokens" type="number" class="model-input" placeholder="4096" min="1" />
 						</div>
 					</div>

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -162,14 +162,12 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 			rb.top_p = um.top_p;
 		}
 
-		// max_tokens
-		if (um?.max_tokens !== undefined) {
-			rb.max_tokens = um.max_tokens;
-		}
-
-		// max_completion_tokens (OpenAI new standard parameter)
+		// max_tokens / max_completion_tokens (mutually exclusive)
+		// max_completion_tokens takes precedence (newer OpenAI standard for reasoning models)
 		if (um?.max_completion_tokens !== undefined) {
 			rb.max_completion_tokens = um.max_completion_tokens;
+		} else if (um?.max_tokens !== undefined) {
+			rb.max_tokens = um.max_tokens;
 		}
 
 		// OpenAI reasoning configuration


### PR DESCRIPTION
Fixes #117 

## Problem
When editing an OpenAI model via the config UI, if only `max_completion_tokens` was set, the UI would populate the legacy `max_tokens` field and on save, both parameters would be sent to the API. This caused errors with providers/models that don't support `max_tokens`:

## Root Cause
The OpenAI Chat Completions API has two mutually exclusive parameters for controlling output length:

- **`max_tokens`** (deprecated) - The legacy parameter, not compatible with o-series reasoning models
- **`max_completion_tokens`** - The newer parameter that includes both visible output tokens and reasoning tokens

Per [OpenAI API documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens):
> `max_tokens` is now deprecated in favor of `max_completion_tokens`, and is **not compatible with o-series models**.

Per [OpenAI Staff (atty-openai)](https://community.openai.com/t/why-was-max-tokens-changed-to-max-completion-tokens/938077/4):
> With the o1 models, `max_tokens` is no longer true — we generate more tokens than we return, as reasoning tokens are not visible. [...] To avoid breaking clients, we are requiring you opt-in to the new behavior by using a new parameter.

## Solution
Added mutual exclusivity logic in openaiApi.ts: if `max_completion_tokens` is defined, only send that parameter; otherwise fall back to `max_tokens`:

This ensures only one parameter is ever sent, regardless of how the model is configured.