### PR TITLE
feat(openai-responses): stateful previous_response_id

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 	"license": "MIT",
 	"enabledApiProposals": [
 		"chatProvider",
-		"languageModelThinkingPart"
+		"languageModelThinkingPart",
+		"languageModelDataPart"
 	],
 	"contributes": {
 		"languageModelChatProviders": [


### PR DESCRIPTION
Note: This approach is inspired by GitHub Copilot Chat’s stateful conversation behavior.

Add stateful conversation support for apiMode: openai-responses using previous_response_id to avoid re-sending full history.
Capture response_id from streaming events and store it as a hidden LanguageModelDataPart marker (per-model).
On the next request, send only messages after the last marker and attach previous_response_id.
Fallback: if a gateway/baseUrl rejects previous_response_id (4xx except 429), retry with full input and cache that baseUrl as unsupported.
Changes: provider.ts, openaiResponsesApi.ts, package.json (enable languageModelDataPart).