### PR TITLE
feat: add apiMode-aware model discovery with Gemini support

### DIFF
--- a/assets/configView/configView.js
+++ b/assets/configView/configView.js
@@ -187,6 +187,7 @@ modelProviderInput.addEventListener("change", () => {
 			type: "fetchModels",
 			baseUrl: state.providerInfo[selectedProvider].baseUrl || state.baseUrl,
 			apiKey: state.providerKeys[selectedProvider] || state.apiKey,
+			apiMode: state.providerInfo[selectedProvider].apiMode || modelApiModeInput.value || "openai",
 		});
 	}
 });
@@ -828,11 +829,17 @@ function populateModelForm(model) {
 		modelProviderInput.appendChild(newOption);
 	}
 
+	const providerInfo = state.providerInfo[currentProvider];
+	const fetchBaseUrl = model.baseUrl || state.baseUrl;
+	const fetchApiKey = state.providerKeys[currentProvider] || state.apiKey;
+	const fetchApiMode = providerInfo?.apiMode || model.apiMode || modelApiModeInput.value || "openai";
+
 	// Request to fetch remote models for the selected provider
 	vscode.postMessage({
 		type: "fetchModels",
-		baseUrl: state.providerInfo[currentProvider].baseUrl || state.baseUrl,
-		apiKey: state.providerKeys[currentProvider] || state.apiKey,
+		baseUrl: fetchBaseUrl,
+		apiKey: fetchApiKey,
+		apiMode: fetchApiMode,
 	});
 
 	modelProviderInput.value = currentProvider;

--- a/src/gemini/geminiTypes.ts
+++ b/src/gemini/geminiTypes.ts
@@ -80,3 +80,15 @@ export interface GeminiGenerateContentResponse {
 	usageMetadata?: unknown;
 	[key: string]: unknown;
 }
+
+export interface GeminiModelListResponse {
+	models?: GeminiModelEntry[];
+	nextPageToken?: string;
+}
+
+export interface GeminiModelEntry {
+	name?: string;
+	displayName?: string;
+	inputTokenLimit?: number;
+	outputTokenLimit?: number;
+}

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -1,9 +1,10 @@
 import * as vscode from "vscode";
 import { CancellationToken, LanguageModelChatInformation } from "vscode";
 
-import type { HFModelItem, HFModelsResponse } from "./types";
+import type { HFApiMode, HFModelItem, HFModelsResponse } from "./types";
 import { normalizeUserModels } from "./utils";
 import { VersionManager } from "./versionManager";
+import { fetchGeminiModels } from "./gemini/geminiApi";
 
 const DEFAULT_CONTEXT_LENGTH = 128000;
 const DEFAULT_MAX_TOKENS = 4096;
@@ -131,7 +132,17 @@ export async function prepareLanguageModelChatInformation(
 /**
  * Fetch the list of models and supplementary metadata from Provider.
  */
-export async function fetchModels(baseUrl: string, apiKey: string): Promise<{ models: HFModelItem[] }> {
+export async function fetchModels(
+	baseUrl: string,
+	apiKey: string,
+	apiMode?: HFApiMode | string
+): Promise<{ models: HFModelItem[] }> {
+	const normalizedApiMode = apiMode ?? "openai";
+	if (normalizedApiMode === "gemini") {
+		const models = await fetchGeminiModels(baseUrl, apiKey);
+		return { models };
+	}
+
 	const modelsList = (async () => {
 		const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/models`, {
 			method: "GET",

--- a/src/views/configView.ts
+++ b/src/views/configView.ts
@@ -30,7 +30,7 @@ type IncomingMessage =
 			commitModel: string;
 			commitLanguage: string;
 	  }
-	| { type: "fetchModels"; baseUrl: string; apiKey: string }
+	| { type: "fetchModels"; baseUrl: string; apiKey: string; apiMode?: HFApiMode | string }
 	| { type: "addProvider"; provider: string; baseUrl?: string; apiKey?: string; apiMode?: string }
 	| { type: "updateProvider"; provider: string; baseUrl?: string; apiKey?: string; apiMode?: string }
 	| { type: "deleteProvider"; provider: string }
@@ -128,7 +128,7 @@ export class ConfigViewPanel {
 				await this.saveGlobalConfig(message.baseUrl, message.apiKey, message.delay, message.retry, message.commitModel, message.commitLanguage);
 				break;
 			case "fetchModels": {
-				const { models } = await fetchModels(message.baseUrl, message.apiKey);
+				const { models } = await fetchModels(message.baseUrl, message.apiKey, message.apiMode);
 				this.panel.webview.postMessage({ type: "modelsFetched", models });
 				break;
 			}


### PR DESCRIPTION
Implements provider-specific model discovery that adapts to different API formats. The Config UI now successfully fetches and displays available models for Gemini providers in addition to existing OpenAI-compatible providers.

- Add fetchGeminiModels() in gemini/geminiApi.ts for Gemini model listing
- Update fetchModels() to route based on apiMode parameter
- Wire apiMode through config UI message handlers
- Implement URL normalization, pagination, and model ID mapping
- Add GeminiModelListResponse and GeminiModelEntry types
- Update frontend to include apiMode in fetchModels requests

Fixes #126 

Both [anthropic](https://platform.claude.com/docs/en/api/models/list) and [openAI](https://platform.openai.com/docs/api-reference/models) return the models under `data`:
```json
{
  "data": [
    {
      "id": "claude-sonnet-4-20250514",
      "created_at": "2025-02-19T00:00:00Z",
      "display_name": "Claude Sonnet 4",
      "type": "model"
    }
  ],
  "first_id": "first_id",
  "has_more": true,
  "last_id": "last_id"
}
```
But [google](https://ai.google.dev/api/models) return them under `models`:

```json
{
  "models": [
    {
      object ([Model](https://ai.google.dev/api/models#Model))
    }
  ],
  "nextPageToken": string
}
```


