### PR TITLE
feat: support custom headers in model listing requests

### DIFF
--- a/src/gemini/geminiApi.ts
+++ b/src/gemini/geminiApi.ts
@@ -1005,12 +1005,17 @@ export class GeminiApi extends CommonApi<GeminiChatMessage, GeminiGenerateConten
  * Supports both native Google Gemini and Langdock Google proxy endpoints.
  * @param baseUrl The Gemini API base URL.
  * @param apiKey The API key for authentication.
+ * @param customHeaders Optional custom headers to merge with defaults.
  * @returns A promise that resolves to an array of model items.
  */
-export async function fetchGeminiModels(baseUrl: string, apiKey: string): Promise<HFModelItem[]> {
+export async function fetchGeminiModels(
+	baseUrl: string,
+	apiKey: string,
+	customHeaders?: Record<string, string>
+): Promise<HFModelItem[]> {
 	const listUrl = buildGeminiModelsUrl(baseUrl);
 	const ownedBy = baseUrl.includes("langdock.com") ? "langdock" : "google";
-	const headers = CommonApi.prepareHeaders(apiKey, "gemini");
+	const headers = CommonApi.prepareHeaders(apiKey, "gemini", customHeaders);
 	headers["Accept"] = "application/json";
 
 	const models: HFModelItem[] = [];

--- a/src/ollama/ollamaApi.ts
+++ b/src/ollama/ollamaApi.ts
@@ -266,15 +266,22 @@ export class OllamaApi extends CommonApi<OllamaMessage, OllamaRequestBody> {
  * Uses /api/tags endpoint to list local models.
  * @param baseUrl The Ollama API base URL.
  * @param _apiKey Ollama doesn't require authentication (ignored).
+ * @param customHeaders Optional custom headers to merge with defaults.
  * @returns A promise that resolves to an array of model items.
  */
-export async function fetchOllamaModels(baseUrl: string, _apiKey: string): Promise<HFModelItem[]> {
+export async function fetchOllamaModels(
+	baseUrl: string,
+	_apiKey: string,
+	customHeaders?: Record<string, string>
+): Promise<HFModelItem[]> {
 	const trimmed = baseUrl.replace(/\/+$/, "");
 	const url = `${trimmed}/api/tags`;
 
+	const baseHeaders: Record<string, string> = { Accept: "application/json" };
+	const headers = customHeaders ? { ...baseHeaders, ...customHeaders } : baseHeaders;
 	const resp = await fetch(url, {
 		method: "GET",
-		headers: { Accept: "application/json" },
+		headers,
 	});
 
 	if (!resp.ok) {

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -136,21 +136,27 @@ export async function prepareLanguageModelChatInformation(
 export async function fetchModels(
 	baseUrl: string,
 	apiKey: string,
-	apiMode?: HFApiMode | string
+	apiMode?: HFApiMode | string,
+	customHeaders?: Record<string, string>
 ): Promise<{ models: HFModelItem[] }> {
 	const normalizedApiMode = apiMode ?? "openai";
 	if (normalizedApiMode === "gemini") {
-		const models = await fetchGeminiModels(baseUrl, apiKey);
+		const models = await fetchGeminiModels(baseUrl, apiKey, customHeaders);
 		return { models };
 	} else if (normalizedApiMode === "ollama") {
-		const models = await fetchOllamaModels(baseUrl, apiKey);
+		const models = await fetchOllamaModels(baseUrl, apiKey, customHeaders);
 		return { models };
 	}
 
 	const modelsList = (async () => {
+		const baseHeaders: Record<string, string> = {
+			Authorization: `Bearer ${apiKey}`,
+			"User-Agent": VersionManager.getUserAgent(),
+		};
+		const headers = customHeaders ? { ...baseHeaders, ...customHeaders } : baseHeaders;
 		const resp = await fetch(`${baseUrl.replace(/\/+$/, "")}/models`, {
 			method: "GET",
-			headers: { Authorization: `Bearer ${apiKey}`, "User-Agent": VersionManager.getUserAgent() },
+			headers,
 		});
 		if (!resp.ok) {
 			let text = "";

--- a/src/views/configView.ts
+++ b/src/views/configView.ts
@@ -52,7 +52,7 @@ type IncomingMessage =
 			commitModel: string;
 			commitLanguage: string;
 	  }
-	| { type: "fetchModels"; baseUrl: string; apiKey: string; apiMode?: HFApiMode | string }
+	| { type: "fetchModels"; baseUrl: string; apiKey: string; apiMode?: HFApiMode | string; headers?: Record<string, string> }
 	| { type: "addProvider"; provider: string; baseUrl?: string; apiKey?: string; apiMode?: string }
 	| { type: "updateProvider"; provider: string; baseUrl?: string; apiKey?: string; apiMode?: string }
 	| { type: "deleteProvider"; provider: string }
@@ -160,8 +160,14 @@ export class ConfigViewPanel {
 				);
 				break;
 			case "fetchModels": {
-				const { models } = await fetchModels(message.baseUrl, message.apiKey, message.apiMode);
-				this.panel.webview.postMessage({ type: "modelsFetched", models });
+				try {
+					const { models } = await fetchModels(message.baseUrl, message.apiKey, message.apiMode, message.headers);
+					this.panel.webview.postMessage({ type: "modelsFetched", models });
+				} catch (err) {
+					console.error("[oaicopilot] fetchModels failed", err);
+					const errorMessage = err instanceof Error ? err.message : String(err);
+					this.panel.webview.postMessage({ type: "modelsFetchError", error: errorMessage });
+				}
 				break;
 			}
 			case "addProvider":


### PR DESCRIPTION
Closes #135

**Changes**
- Add customHeaders parameter to fetchModels, fetchGeminiModels, fetchOllamaModels
- Pass headers from model config when fetching remote model lists in config UI
- Add error handling for fetchModels with user feedback in dropdown
- Custom headers now work for all API modes (OpenAI, Gemini, Ollama)

**Testing**
1. Configure a model with custom headers (e.g., {"User-Agent": "Mozilla/5.0..."})
2. Open config UI and edit the model
3. Model dropdown should now populate successfully if it failed before; or show an error if it fails.