### PR TITLE
✨ feat(commit): add configurable commit message prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,8 +345,26 @@
 								"description": "Model-specific delay in milliseconds between consecutive requests. If not specified, falls back to global oaicopilot.delay configuration."
 							}
 						},
-						"required": ["id"],
-						"anyOf": [{ "required": ["owned_by"] }, { "required": ["provider"] }, { "required": ["provide"] }]
+						"required": [
+							"id"
+						],
+						"anyOf": [
+							{
+								"required": [
+									"owned_by"
+								]
+							},
+							{
+								"required": [
+									"provider"
+								]
+							},
+							{
+								"required": [
+									"provide"
+								]
+							}
+						]
 					},
 					"description": "A list of preferred models to use. If provided, these models will be used directly instead of fetching from the API."
 				},
@@ -412,6 +430,11 @@
 						"Polish"
 					],
 					"description": "Language for generated Git commit messages. Default is English."
+				},
+				"oaicopilot.commitMessagePrompt": {
+					"type": "string",
+					"default": "",
+					"description": "Custom system prompt for commit message generation. If not provided, uses the default prompt."
 				},
 				"oaicopilot.readFileLines": {
 					"type": "number",


### PR DESCRIPTION
- add DEFAULT_PROMPT constant with structured system and user prompt sections
- refactor performCommitMsgGeneration to read custom system prompt from vscode configuration
- allow users to override the default commit generation prompt via 'oaicopilot.commitMessagePrompt' setting
- move config retrieval earlier in the function to use for prompt customization
- remove hardcoded instruction array and use configurable prompt system