### PR TITLE
fix(configView): no flex in table to avoid misalignment; sync style

### DIFF
--- a/assets/configView/configView.css
+++ b/assets/configView/configView.css
@@ -249,8 +249,6 @@ tr:hover {
 }
 
 .action-buttons {
-	display: flex;
-	gap: 8px;
 	white-space: nowrap;
 }
 

--- a/assets/configView/configView.js
+++ b/assets/configView/configView.js
@@ -369,7 +369,7 @@ function renderProviders() {
 					</select>
 				</td>
 				<td><textarea class="provider-input" data-field="headers" rows="2" placeholder='{"X-API-Version": "v1"}' style="width: 100%; font-family: monospace; font-size: 12px;">${headersJson}</textarea></td>
-				<td>
+				<td class="action-buttons">
 					<button class="update-provider-btn" data-provider="${provider}">Save</button>
 					<button class="delete-provider-btn danger" data-provider="${provider}">Delete</button>
 				</td>


### PR DESCRIPTION
Hi.

I assume the "flex" layout is for spacing between buttons. We already have `margin-right: 8px` for buttons, so they will look fine without the flex box.

https://github.com/JohnnyZ93/oai-compatible-copilot/blob/aa0e03f2451b7e37342eab9cab21a5134fe56e97/assets/configView/configView.css#L43-L44

Anyway, `display: flex` did break the table and has been removed by me. I've also made the similar column in the "Provider Management" table look the same. Here is the screenshot for comparison:

<img width="600" alt="Screenshot of comparison about this PR in the OAICopilot Configuration page" src="https://github.com/user-attachments/assets/001f86fd-1778-4c51-a80d-e199b9172ea0" />

Tested this PR within Developer Tools in VS Code 1.109.2. Hope this helps.
