### PR TITLE
feat: add fallback chain support for OAI-compatible model endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ out
 dist
 node_modules
 .vscode-test/
+.vscode-local-ext/
+.vscode-local-user/
 *.vsix
 .DS_Store
 CLAUDE.md

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,6 @@
 .vscode/**
+.vscode-local-ext/**
+.vscode-local-user/**
 .vscode-test/**
 src/**
 .gitignore
@@ -14,3 +16,4 @@ vsc-extension-quickstart.md
 .vscode-test.mjs
 eslint.config.mjs
 AGENTS.md
+extension.vsix

--- a/package.json
+++ b/package.json
@@ -157,6 +157,47 @@
 								"type": "string",
 								"description": "Base URL for the model provider. If not provided, the global oaicopilot.baseUrl will be used."
 							},
+							"fallbacks": {
+								"type": "array",
+								"items": {
+									"oneOf": [
+										{
+											"type": "string",
+											"description": "Fallback model reference. Use 'model-id', 'model-id::config-id', or 'provider|model-id' to disambiguate the same model ID across providers."
+										},
+										{
+											"type": "object",
+											"properties": {
+												"id": {
+													"type": "string",
+													"description": "Fallback model ID. Supports 'model-id::config-id'."
+												},
+												"modelId": {
+													"type": "string",
+													"description": "Fallback model ID. Supports 'model-id::config-id'."
+												},
+												"configId": {
+													"type": "string",
+													"description": "Optional fallback config ID when the same model is configured multiple times."
+												},
+												"owned_by": {
+													"type": "string",
+													"description": "Optional provider hint to disambiguate the fallback target."
+												},
+												"provider": {
+													"type": "string",
+													"description": "Alias of owned_by for the fallback target."
+												},
+												"provide": {
+													"type": "string",
+													"description": "Alias of owned_by for the fallback target."
+												}
+											}
+										}
+									]
+								},
+								"description": "Ordered fallback chain for this model. Each entry must reference another model configured in oaicopilot.models. Use 'provider|model-id' or an object with owned_by/provider when the same model ID exists under multiple providers."
+							},
 							"context_length": {
 								"type": "number",
 								"default": 128000,

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -289,8 +289,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			const errorType = chunk.error?.type || "unknown_error";
 			const errorMessage = chunk.error?.message || "Anthropic API streaming error";
 			console.error(`[Anthropic Provider] Streaming error: ${errorType} - ${errorMessage}`);
-			// We could throw here, but for now just log and continue
-			return;
+			throw new Error(`Anthropic API streaming error: ${errorType} - ${errorMessage}`);
 		}
 
 		if (chunk.type === "message_start" && chunk.message) {

--- a/src/fallbackExecutor.ts
+++ b/src/fallbackExecutor.ts
@@ -1,0 +1,130 @@
+import type {
+	CancellationToken,
+	LanguageModelChatRequestMessage,
+	LanguageModelResponsePart2,
+	Progress,
+	ProvideLanguageModelChatResponseOptions,
+} from "vscode";
+
+import type { FallbackModelRef, HFApiMode, HFModelItem, RetryConfig, RuntimeResponsePart } from "./types";
+import { createRetryConfig, isRetryableError } from "./utils";
+
+const FALLBACK_ELIGIBLE_STATUS_CODES = [401, 403, 404, 405];
+
+export interface ResolvedChatModelTarget {
+	resolvedModelId: string;
+	requestModelId: string;
+	userModel: HFModelItem;
+	baseUrl: string;
+	apiKey: string;
+	apiMode: HFApiMode;
+	selectedModelId: string;
+	selectedProvider?: string;
+	failoverReason?: string;
+}
+
+export interface ChatRequestContext {
+	messages: readonly LanguageModelChatRequestMessage[];
+	options: ProvideLanguageModelChatResponseOptions;
+	progress: Progress<LanguageModelResponsePart2>;
+	token: CancellationToken;
+}
+
+export type ResolveFallbackTarget = (fallback: FallbackModelRef) => Promise<ResolvedChatModelTarget | undefined>;
+
+export type ChatRequestFn = (
+	target: ResolvedChatModelTarget,
+	ctx: ChatRequestContext,
+	retryConfig: RetryConfig
+) => Promise<void>;
+
+class BufferedProgress implements Progress<LanguageModelResponsePart2> {
+	private readonly parts: RuntimeResponsePart[] = [];
+
+	report(part: LanguageModelResponsePart2): void {
+		this.parts.push(part);
+	}
+
+	hasBufferedParts(): boolean {
+		return this.parts.length > 0;
+	}
+
+	replay(target: Progress<LanguageModelResponsePart2>): void {
+		for (const part of this.parts) {
+			target.report(part);
+		}
+	}
+}
+
+export class FallbackExecutor {
+	async executeWithFallback(
+		primaryTarget: ResolvedChatModelTarget,
+		fallbacks: readonly FallbackModelRef[] | undefined,
+		resolveFallbackTarget: ResolveFallbackTarget,
+		requestFn: ChatRequestFn,
+		ctx: ChatRequestContext
+	): Promise<void> {
+		const retryConfig = createRetryConfig();
+		const targets: ResolvedChatModelTarget[] = [primaryTarget];
+		const seen = new Set([primaryTarget.resolvedModelId]);
+
+		for (const fallback of fallbacks ?? []) {
+			const target = await resolveFallbackTarget(fallback);
+			if (!target) {
+				console.warn("[OAI Compatible Model Provider] Failed to resolve fallback model", fallback);
+				continue;
+			}
+			if (seen.has(target.resolvedModelId)) {
+				continue;
+			}
+			seen.add(target.resolvedModelId);
+			targets.push(target);
+		}
+
+		const errors: Error[] = [];
+
+		for (let index = 0; index < targets.length; index++) {
+			const target =
+				index === 0
+					? targets[index]
+					: {
+						...targets[index],
+						selectedModelId: primaryTarget.requestModelId,
+						selectedProvider: primaryTarget.userModel.owned_by,
+						failoverReason: errors.length > 0 ? errors[errors.length - 1].message : undefined,
+					  };
+			const bufferedProgress = new BufferedProgress();
+			const bufferedContext: ChatRequestContext = {
+				...ctx,
+				progress: bufferedProgress,
+			};
+
+			try {
+				if (index > 0) {
+					console.warn(
+						`[OAI Compatible Model Provider] Falling back to model ${target.resolvedModelId} (${target.baseUrl})`
+					);
+				}
+				await requestFn(target, bufferedContext, retryConfig);
+				bufferedProgress.replay(ctx.progress);
+				return;
+			} catch (error) {
+				const normalizedError = error instanceof Error ? error : new Error(String(error));
+				errors.push(normalizedError);
+
+				if (!this.isFallbackEligible(normalizedError, retryConfig) && index < targets.length - 1) {
+					throw normalizedError;
+				}
+			}
+		}
+
+		const details = errors.map((error, index) => `[${index + 1}/${errors.length}] ${error.message}`).join("\n");
+		throw new Error(
+			`All configured endpoints failed for ${primaryTarget.resolvedModelId}.${details ? `\n${details}` : ""}`
+		);
+	}
+
+	private isFallbackEligible(error: Error, retryConfig: RetryConfig): boolean {
+		return isRetryableError(error, retryConfig, FALLBACK_ELIGIBLE_STATUS_CODES);
+	}
+}

--- a/src/gemini/geminiApi.ts
+++ b/src/gemini/geminiApi.ts
@@ -804,6 +804,10 @@ export class GeminiApi extends CommonApi<GeminiChatMessage, GeminiGenerateConten
 					if (!payload) {
 						continue;
 					}
+					const payloadRecord = payload as Record<string, unknown>;
+					if (payloadRecord.error) {
+						throw new Error(`Gemini API streaming error: ${JSON.stringify(payloadRecord.error)}`);
+					}
 
 					const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
 					const cand = candidates.length > 0 ? candidates[0] : null;

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -302,10 +302,17 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 
 					try {
 						const parsed = JSON.parse(data);
+						const errorMessage = this.extractStreamingError(parsed);
+						if (errorMessage) {
+							throw new Error(`OAI Compatible API streaming error: ${errorMessage}`);
+						}
 						// console.debug("[OAI Compatible Model Provider] data:", JSON.stringify(parsed));
 
 						await this.processDelta(parsed, progress);
-					} catch {
+					} catch (error) {
+						if (error instanceof Error && /streaming error/i.test(error.message)) {
+							throw error;
+						}
 						// Silently ignore malformed SSE lines temporarily
 					}
 				}
@@ -315,6 +322,24 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 			// If there's an active thinking sequence, end it first
 			this.reportEndThinking(progress);
 		}
+	}
+
+	private extractStreamingError(payload: Record<string, unknown>): string | undefined {
+		const error = payload.error;
+		if (!error) {
+			return undefined;
+		}
+		if (typeof error === "string") {
+			return error;
+		}
+		if (typeof error === "object") {
+			const obj = error as Record<string, unknown>;
+			const message = typeof obj.message === "string" ? obj.message : "";
+			const type = typeof obj.type === "string" ? obj.type : "";
+			const code = typeof obj.code === "string" ? obj.code : "";
+			return [type, code, message].filter(Boolean).join(": ");
+		}
+		return undefined;
 	}
 
 	/**

--- a/src/openai/openaiResponsesApi.ts
+++ b/src/openai/openaiResponsesApi.ts
@@ -321,8 +321,14 @@ export class OpenaiResponsesApi extends CommonApi<ResponsesInputItem, Record<str
 
 					try {
 						const parsed = JSON.parse(data) as Record<string, unknown>;
+						if (parsed.error) {
+							throw new Error(`Responses API streaming error: ${JSON.stringify(parsed.error)}`);
+						}
 						await this.processEvent(parsed, progress);
-					} catch {
+					} catch (error) {
+						if (error instanceof Error && /Responses API streaming error/i.test(error.message)) {
+							throw error;
+						}
 						// Silently ignore malformed SSE lines
 					}
 				}
@@ -406,7 +412,7 @@ export class OpenaiResponsesApi extends CommonApi<ResponsesInputItem, Record<str
 			case "error": {
 				const errorText = JSON.stringify(event);
 				console.error("[OAI Compatible Model Provider] Responses API streaming process error:", errorText);
-				return;
+				throw new Error(`Responses API streaming error: ${errorText}`);
 			}
 
 			// Output text delta events

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -25,6 +25,10 @@ export async function prepareLanguageModelChatInformation(
 	// Check for user-configured models first
 	const config = vscode.workspace.getConfiguration();
 	const userModels = normalizeUserModels(config.get<unknown>("oaicopilot.models", []));
+	const modelIdCounts = new Map<string, number>();
+	for (const userModel of userModels) {
+		modelIdCounts.set(userModel.id, (modelIdCounts.get(userModel.id) ?? 0) + 1);
+	}
 
 	let infos: LanguageModelChatInformation[];
 	if (userModels && userModels.length > 0) {
@@ -38,7 +42,14 @@ export async function prepareLanguageModelChatInformation(
 
 				// 使用配置ID（如果存在）来生成唯一的模型ID
 				const modelId = m.configId ? `${m.id}::${m.configId}` : m.id;
-				const modelName = m.displayName || (m.configId ? `${m.id}::${m.configId}` : `${m.id}`);
+				const hasDuplicateModelId = (modelIdCounts.get(m.id) ?? 0) > 1;
+				const modelName =
+					m.displayName ||
+					(m.configId
+						? `${m.id}::${m.configId}`
+						: hasDuplicateModelId && m.owned_by
+							? `${m.id} (${m.owned_by})`
+							: `${m.id}`);
 				const detail = m.owned_by ? `${m.owned_by} (${EXTENSION_LABEL})` : EXTENSION_LABEL;
 
 				return {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -9,11 +9,11 @@ import {
 	Progress,
 } from "vscode";
 
-import type { HFModelItem } from "./types";
+import type { FallbackModelRef, HFModelItem, RetryConfig } from "./types";
 
 import type { OllamaRequestBody } from "./ollama/ollamaTypes";
 
-import { parseModelId, createRetryConfig, executeWithRetry, normalizeUserModels } from "./utils";
+import { buildResolvedModelKey, parseModelId, executeWithRetry, normalizeUserModels } from "./utils";
 
 import { prepareLanguageModelChatInformation } from "./provideModel";
 import { prepareTokenCount } from "./provideToken";
@@ -25,6 +25,7 @@ import { AnthropicRequestBody } from "./anthropic/anthropicTypes";
 import { GeminiApi, buildGeminiGenerateContentUrl, type GeminiToolCallMeta } from "./gemini/geminiApi";
 import type { GeminiGenerateContentRequest } from "./gemini/geminiTypes";
 import { CommonApi } from "./commonApi";
+import { ChatRequestContext, FallbackExecutor, ResolvedChatModelTarget } from "./fallbackExecutor";
 
 /**
  * VS Code Chat provider backed by Hugging Face Inference Providers.
@@ -32,6 +33,8 @@ import { CommonApi } from "./commonApi";
 export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	/** Track last request completion time for delay calculation. */
 	private _lastRequestTime: number | null = null;
+
+	private readonly fallbackExecutor = new FallbackExecutor();
 
 	private readonly _geminiToolCallMetaByCallId = new Map<string, GeminiToolCallMeta>();
 	private readonly _openaiResponsesPreviousResponseIdUnsupportedBaseUrls = new Set<string>();
@@ -124,11 +127,6 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				um = userModels.find((um) => um.id === parsedModelId.baseId);
 			}
 
-			// Prepare model configuration
-			const modelConfig = {
-				includeReasoningInRequest: um?.include_reasoning_in_request ?? false,
-			};
-
 			// Apply delay between consecutive requests
 			const modelDelay = um?.delay;
 			const globalDelay = config.get<number>("oaicopilot.delay", 0);
@@ -147,314 +145,26 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				}
 			}
 
-			// Get API key for the model's provider
-			const provider = um?.owned_by;
-			const useGenericKey = !um?.baseUrl;
-			const modelApiKey = await this.ensureApiKey(useGenericKey, provider);
-			if (!modelApiKey) {
-				throw new Error("OAI Compatible API key not found");
-			}
+			const primaryModel: HFModelItem = um ?? {
+				id: parsedModelId.baseId,
+				configId: parsedModelId.configId,
+				owned_by: "",
+			};
+			const primaryTarget = await this.resolveChatModelTarget(primaryModel, model.id, config);
+			const requestContext: ChatRequestContext = {
+				messages,
+				options,
+				progress: trackingProgress,
+				token,
+			};
 
-			// send chat request
-			const BASE_URL = um?.baseUrl || config.get<string>("oaicopilot.baseUrl", "");
-			if (!BASE_URL || !BASE_URL.startsWith("http")) {
-				throw new Error(`Invalid base URL configuration.`);
-			}
-
-			// get retry config
-			const retryConfig = createRetryConfig();
-
-			// Check if using Ollama native API mode
-			const apiMode = um?.apiMode ?? "openai";
-
-			// prepare headers with custom headers if specified
-			const requestHeaders = CommonApi.prepareHeaders(modelApiKey, apiMode, um?.headers);
-
-			// console.debug("[OAI Compatible Model Provider] messages:", JSON.stringify(messages));
-			if (apiMode === "ollama") {
-				// Ollama native API mode
-				const ollamaApi = new OllamaApi();
-				const ollamaMessages = ollamaApi.convertMessages(messages, modelConfig);
-
-				let ollamaRequestBody: OllamaRequestBody = {
-					model: parsedModelId.baseId,
-					messages: ollamaMessages,
-					stream: true,
-				};
-				ollamaRequestBody = ollamaApi.prepareRequestBody(ollamaRequestBody, um, options);
-				// console.debug("[OAI Compatible Model Provider] RequestBody:", JSON.stringify(ollamaRequestBody));
-
-				// send Ollama chat request with retry
-				const url = `${BASE_URL.replace(/\/+$/, "")}/api/chat`;
-				const response = await executeWithRetry(async () => {
-					const res = await fetch(url, {
-						method: "POST",
-						headers: requestHeaders,
-						body: JSON.stringify(ollamaRequestBody),
-					});
-
-					if (!res.ok) {
-						const errorText = await res.text();
-						console.error("[Ollama Provider] Ollama API error response", errorText);
-						throw new Error(
-							`Ollama API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
-						);
-					}
-
-					return res;
-				}, retryConfig);
-
-				if (!response.body) {
-					throw new Error("No response body from Ollama API");
-				}
-				await ollamaApi.processStreamingResponse(response.body, trackingProgress, token);
-			} else if (apiMode === "anthropic") {
-				// Anthropic API mode
-				const anthropicApi = new AnthropicApi();
-				const anthropicMessages = anthropicApi.convertMessages(messages, modelConfig);
-
-				// requestBody
-				let requestBody: AnthropicRequestBody = {
-					model: parsedModelId.baseId,
-					messages: anthropicMessages,
-					stream: true,
-				};
-				requestBody = anthropicApi.prepareRequestBody(requestBody, um, options);
-				// console.debug("[OAI Compatible Model Provider] RequestBody:", JSON.stringify(requestBody));
-
-				// send Anthropic chat request with retry
-				const normalizedBaseUrl = BASE_URL.replace(/\/+$/, "");
-				// Some providers require configuring the baseUrl with a version suffix (e.g. .../v1).
-				// Avoid double-appending (e.g. .../v1/v1/messages).
-				const url = normalizedBaseUrl.endsWith("/v1")
-					? `${normalizedBaseUrl}/messages`
-					: `${normalizedBaseUrl}/v1/messages`;
-				const response = await executeWithRetry(async () => {
-					const res = await fetch(url, {
-						method: "POST",
-						headers: requestHeaders,
-						body: JSON.stringify(requestBody),
-					});
-
-					if (!res.ok) {
-						const errorText = await res.text();
-						console.error("[Anthropic Provider] Anthropic API error response", errorText);
-						throw new Error(
-							`Anthropic API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
-						);
-					}
-
-					return res;
-				}, retryConfig);
-
-				if (!response.body) {
-					throw new Error("No response body from Anthropic API");
-				}
-				await anthropicApi.processStreamingResponse(response.body, trackingProgress, token);
-			} else if (apiMode === "openai-responses") {
-				// OpenAI Responses API mode
-				const openaiResponsesApi = new OpenaiResponsesApi();
-				const normalizedBaseUrl = BASE_URL.replace(/\/+$/, "");
-				const statefulModelId = parsedModelId.baseId;
-
-				// Convert full history once (also extracts system `instructions`).
-				const fullInput = openaiResponsesApi.convertMessages(messages, modelConfig);
-
-				const marker = findLastOpenAIResponsesStatefulMarker(statefulModelId, messages);
-				let deltaInput: unknown[] | null = null;
-				if (marker && marker.index >= 0 && marker.index < messages.length - 1) {
-					const deltaMessages = messages.slice(marker.index + 1);
-					const converted = openaiResponsesApi.convertMessages(deltaMessages, modelConfig);
-					if (converted.length > 0) {
-						deltaInput = converted;
-					}
-				}
-
-				const canUsePreviousResponseId =
-					!!marker?.marker &&
-					!this._openaiResponsesPreviousResponseIdUnsupportedBaseUrls.has(normalizedBaseUrl) &&
-					Array.isArray(deltaInput) &&
-					deltaInput.length > 0;
-
-				const input = canUsePreviousResponseId ? deltaInput! : fullInput;
-
-				// requestBody
-				let requestBody: Record<string, unknown> = {
-					model: parsedModelId.baseId,
-					input,
-					stream: true,
-				};
-
-				requestBody = openaiResponsesApi.prepareRequestBody(requestBody, um, options);
-
-				// send Responses API request with retry
-				const url = `${normalizedBaseUrl}/responses`;
-
-				// If the user explicitly set `previous_response_id` via `extra`, don't apply stateful slicing.
-				let addedPreviousResponseId = false;
-				if (requestBody.previous_response_id !== undefined) {
-					requestBody.input = fullInput;
-				} else if (canUsePreviousResponseId) {
-					requestBody.previous_response_id = marker!.marker;
-					addedPreviousResponseId = true;
-				}
-
-				const sendRequest = async (body: Record<string, unknown>) =>
-					await executeWithRetry(async () => {
-						const res = await fetch(url, {
-							method: "POST",
-							headers: requestHeaders,
-							body: JSON.stringify(body),
-						});
-
-						if (!res.ok) {
-							const errorText = await res.text();
-							const error = new Error(
-								`Responses API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
-							);
-							(error as { status?: number; errorText?: string }).status = res.status;
-							(error as { status?: number; errorText?: string }).errorText = errorText;
-							throw error;
-						}
-
-						return res;
-					}, retryConfig);
-
-				let response: Response;
-				try {
-					response = await sendRequest(requestBody);
-				} catch (err) {
-					// Some Responses-compatible gateways don't support `previous_response_id`.
-					// Fall back to sending full history when the previous-response attempt fails.
-					const status = (err as { status?: unknown })?.status;
-					const shouldFallback =
-						addedPreviousResponseId && typeof status === "number" && status >= 400 && status < 500 && status !== 429;
-					if (!shouldFallback) {
-						throw err;
-					}
-
-					this._openaiResponsesPreviousResponseIdUnsupportedBaseUrls.add(normalizedBaseUrl);
-
-					let fallbackBody: Record<string, unknown> = {
-						model: parsedModelId.baseId,
-						input: fullInput,
-						stream: true,
-					};
-					fallbackBody = openaiResponsesApi.prepareRequestBody(fallbackBody, um, options);
-					delete fallbackBody.previous_response_id;
-					response = await sendRequest(fallbackBody);
-				}
-
-				if (!response.body) {
-					throw new Error("No response body from Responses API");
-				}
-				await openaiResponsesApi.processStreamingResponse(response.body, trackingProgress, token);
-
-				// Append a stateful marker so future requests can reuse `previous_response_id` (Copilot Chat style).
-				const responseId = openaiResponsesApi.responseId;
-				if (responseId) {
-					trackingProgress.report(createOpenAIResponsesStatefulMarkerPart(statefulModelId, responseId));
-				}
-			} else if (apiMode === "gemini") {
-				// Gemini native API mode
-				const geminiApi = new GeminiApi(this._geminiToolCallMetaByCallId);
-				const geminiMessages = geminiApi.convertMessages(messages, modelConfig);
-
-				const systemParts: string[] = [];
-				const contents: GeminiGenerateContentRequest["contents"] = [];
-				for (const msg of geminiMessages) {
-					if (msg.role === "system") {
-						const text = msg.parts
-							.map((p) =>
-								p && typeof p === "object" && typeof (p as { text?: unknown }).text === "string"
-									? String((p as { text: string }).text)
-									: ""
-							)
-							.join("")
-							.trim();
-						if (text) {
-							systemParts.push(text);
-						}
-						continue;
-					}
-					contents.push({ role: msg.role, parts: msg.parts });
-				}
-
-				let requestBody: GeminiGenerateContentRequest = {
-					contents,
-				};
-				if (systemParts.length > 0) {
-					requestBody.systemInstruction = { role: "user", parts: [{ text: systemParts.join("\n") }] };
-				}
-				requestBody = geminiApi.prepareRequestBody(requestBody, um, options);
-
-				const url = buildGeminiGenerateContentUrl(BASE_URL, parsedModelId.baseId, true);
-				if (!url) {
-					throw new Error("Invalid Gemini base URL configuration.");
-				}
-
-				const response = await executeWithRetry(async () => {
-					const res = await fetch(url, {
-						method: "POST",
-						headers: requestHeaders,
-						body: JSON.stringify(requestBody),
-					});
-
-					if (!res.ok) {
-						const errorText = await res.text();
-						console.error("[Gemini Provider] Gemini API error response", errorText);
-						throw new Error(
-							`Gemini API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
-						);
-					}
-
-					return res;
-				}, retryConfig);
-
-				if (!response.body) {
-					throw new Error("No response body from Gemini API");
-				}
-				await geminiApi.processStreamingResponse(response.body, trackingProgress, token);
-			} else {
-				// OpenAI compatible API mode (default)
-				const openaiApi = new OpenaiApi();
-				const openaiMessages = openaiApi.convertMessages(messages, modelConfig);
-
-				// requestBody
-				let requestBody: Record<string, unknown> = {
-					model: parsedModelId.baseId,
-					messages: openaiMessages,
-					stream: true,
-					stream_options: { include_usage: true },
-				};
-				requestBody = openaiApi.prepareRequestBody(requestBody, um, options);
-				// console.debug("[OAI Compatible Model Provider] RequestBody:", JSON.stringify(requestBody));
-
-				// send chat request with retry
-				const url = `${BASE_URL.replace(/\/+$/, "")}/chat/completions`;
-				const response = await executeWithRetry(async () => {
-					const res = await fetch(url, {
-						method: "POST",
-						headers: requestHeaders,
-						body: JSON.stringify(requestBody),
-					});
-
-					if (!res.ok) {
-						const errorText = await res.text();
-						console.error("[OAI Compatible Model Provider] OAI Compatible API error response", errorText);
-						throw new Error(
-							`OAI Compatible API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
-						);
-					}
-
-					return res;
-				}, retryConfig);
-
-				if (!response.body) {
-					throw new Error("No response body from OAI Compatible API");
-				}
-				await openaiApi.processStreamingResponse(response.body, trackingProgress, token);
-			}
+			await this.fallbackExecutor.executeWithFallback(
+				primaryTarget,
+				um?.fallbacks,
+				async (fallback) => await this.resolveFallbackTarget(fallback, userModels, config),
+				this.executeChatRequest.bind(this),
+				requestContext
+			);
 		} catch (err) {
 			console.error("[OAI Compatible Model Provider] Chat request failed", {
 				modelId: model.id,
@@ -466,6 +176,448 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			// Update last request time after successful completion
 			this._lastRequestTime = Date.now();
 		}
+	}
+
+	private findConfiguredModel(
+		userModels: readonly HFModelItem[],
+		modelId: string,
+		configId?: string,
+		provider?: string
+	): HFModelItem | undefined {
+		const normalizedProvider = provider?.trim().toLowerCase();
+		const candidates = userModels.filter((userModel) => {
+			if (userModel.id !== modelId) {
+				return false;
+			}
+			if (!normalizedProvider) {
+				return true;
+			}
+			return userModel.owned_by?.trim().toLowerCase() === normalizedProvider;
+		});
+
+		if (candidates.length === 0) {
+			return undefined;
+		}
+
+		if (configId) {
+			const configCandidates = candidates.filter((candidate) => candidate.configId === configId);
+			if (configCandidates.length <= 1) {
+				return configCandidates[0] ?? candidates[0];
+			}
+
+			console.warn(
+				`[OAI Compatible Model Provider] Ambiguous model '${modelId}::${configId}' across multiple providers. Specify fallback provider explicitly.`
+			);
+			return undefined;
+		}
+
+		const defaultCandidates = candidates.filter((candidate) => !candidate.configId);
+		if (defaultCandidates.length === 1) {
+			return defaultCandidates[0];
+		}
+
+		if (defaultCandidates.length > 1 || candidates.length > 1) {
+			console.warn(
+				`[OAI Compatible Model Provider] Ambiguous model '${modelId}' across multiple providers. Specify fallback provider explicitly.`
+			);
+			return undefined;
+		}
+
+		return candidates[0];
+	}
+
+	private async resolveFallbackTarget(
+		fallback: FallbackModelRef,
+		userModels: readonly HFModelItem[],
+		config: vscode.WorkspaceConfiguration
+	): Promise<ResolvedChatModelTarget | undefined> {
+		const rawModelId = fallback.modelId ?? fallback.id;
+		if (!rawModelId) {
+			return undefined;
+		}
+
+		const resolvedModel = this.findConfiguredModel(userModels, rawModelId, fallback.configId, fallback.owned_by);
+		if (!resolvedModel) {
+			console.warn(
+				`[OAI Compatible Model Provider] Could not resolve fallback model '${rawModelId}'. If multiple providers expose this model ID, specify 'owned_by' or use 'provider|modelId'.`
+			);
+			return undefined;
+		}
+
+		return await this.resolveChatModelTarget(
+			resolvedModel,
+			buildResolvedModelKey(resolvedModel.owned_by, resolvedModel.id, resolvedModel.configId),
+			config
+		);
+	}
+
+	private async resolveChatModelTarget(
+		userModel: HFModelItem,
+		resolvedModelId: string,
+		config: vscode.WorkspaceConfiguration
+	): Promise<ResolvedChatModelTarget> {
+		const baseUrl = userModel.baseUrl || config.get<string>("oaicopilot.baseUrl", "");
+		if (!baseUrl || !baseUrl.startsWith("http")) {
+			throw new Error("Invalid base URL configuration.");
+		}
+
+		const provider = userModel.owned_by?.trim() || undefined;
+		const useGenericKey = !userModel.baseUrl;
+		const apiKey = await this.ensureApiKey(useGenericKey, provider);
+		if (!apiKey) {
+			throw new Error("OAI Compatible API key not found");
+		}
+
+		return {
+			resolvedModelId,
+			requestModelId: userModel.id,
+			userModel,
+			baseUrl,
+			apiKey,
+			apiMode: userModel.apiMode ?? "openai",
+			selectedModelId: userModel.id,
+			selectedProvider: userModel.owned_by,
+		};
+	}
+
+	private getRoutingInstruction(target: ResolvedChatModelTarget): string | undefined {
+		const actualProvider = target.userModel.owned_by?.trim() || undefined;
+		const selectedProvider = target.selectedProvider?.trim() || undefined;
+		const modelChanged = target.selectedModelId !== target.requestModelId;
+		const providerChanged = selectedProvider !== actualProvider;
+
+		if (!modelChanged && !providerChanged) {
+			return undefined;
+		}
+
+		const selectedLabel = selectedProvider
+			? `${target.selectedModelId} via provider ${selectedProvider}`
+			: target.selectedModelId;
+		const actualLabel = actualProvider ? `${target.requestModelId} via provider ${actualProvider}` : target.requestModelId;
+		const failoverReason = target.failoverReason ? target.failoverReason.split("\n")[0].trim() : undefined;
+
+		return [
+			`Routing notice: the user selected ${selectedLabel}, but this request was automatically routed to ${actualLabel} because the original route failed.`,
+			failoverReason ? `The previous route failed with: ${failoverReason}.` : "",
+			`If asked which model you are, identify yourself as ${actualLabel}.`,
+			`Do not claim to be ${selectedLabel} for this response.`,
+			`If you provide a direct user-facing answer in this turn, end with one brief sentence noting that the response was automatically rerouted after an upstream model failure.`
+		].join(" ");
+	}
+
+	private async executeChatRequest(
+		target: ResolvedChatModelTarget,
+		ctx: ChatRequestContext,
+		retryConfig: RetryConfig
+	): Promise<void> {
+		const { messages, options, progress, token } = ctx;
+		const { apiKey, apiMode, baseUrl, requestModelId, userModel } = target;
+		const modelConfig = {
+			includeReasoningInRequest: userModel.include_reasoning_in_request ?? false,
+		};
+		const routingInstruction = this.getRoutingInstruction(target);
+		const requestHeaders = CommonApi.prepareHeaders(apiKey, apiMode, userModel.headers);
+
+		if (apiMode === "ollama") {
+			const ollamaApi = new OllamaApi();
+			const ollamaMessages = ollamaApi.convertMessages(messages, modelConfig);
+			if (routingInstruction) {
+				ollamaMessages.unshift({
+					role: "system",
+					content: routingInstruction,
+				});
+			}
+
+			let ollamaRequestBody: OllamaRequestBody = {
+				model: requestModelId,
+				messages: ollamaMessages,
+				stream: true,
+			};
+			ollamaRequestBody = ollamaApi.prepareRequestBody(ollamaRequestBody, userModel, options);
+
+			const url = `${baseUrl.replace(/\/+$/, "")}/api/chat`;
+			const response = await executeWithRetry(async () => {
+				const res = await fetch(url, {
+					method: "POST",
+					headers: requestHeaders,
+					body: JSON.stringify(ollamaRequestBody),
+				});
+
+				if (!res.ok) {
+					const errorText = await res.text();
+					console.error("[Ollama Provider] Ollama API error response", errorText);
+					throw new Error(
+						`Ollama API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+					);
+				}
+
+				return res;
+			}, retryConfig);
+
+			if (!response.body) {
+				throw new Error("No response body from Ollama API");
+			}
+			await ollamaApi.processStreamingResponse(response.body, progress, token);
+			return;
+		}
+
+		if (apiMode === "anthropic") {
+			const anthropicApi = new AnthropicApi();
+			const anthropicMessages = anthropicApi.convertMessages(messages, modelConfig);
+
+			let requestBody: AnthropicRequestBody = {
+				model: requestModelId,
+				messages: anthropicMessages,
+				stream: true,
+			};
+			requestBody = anthropicApi.prepareRequestBody(requestBody, userModel, options);
+			if (routingInstruction) {
+				requestBody.system = requestBody.system
+					? `${requestBody.system}\n\n${routingInstruction}`
+					: routingInstruction;
+			}
+
+			const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+			const url = normalizedBaseUrl.endsWith("/v1")
+				? `${normalizedBaseUrl}/messages`
+				: `${normalizedBaseUrl}/v1/messages`;
+			const response = await executeWithRetry(async () => {
+				const res = await fetch(url, {
+					method: "POST",
+					headers: requestHeaders,
+					body: JSON.stringify(requestBody),
+				});
+
+				if (!res.ok) {
+					const errorText = await res.text();
+					console.error("[Anthropic Provider] Anthropic API error response", errorText);
+					throw new Error(
+						`Anthropic API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+					);
+				}
+
+				return res;
+			}, retryConfig);
+
+			if (!response.body) {
+				throw new Error("No response body from Anthropic API");
+			}
+			await anthropicApi.processStreamingResponse(response.body, progress, token);
+			return;
+		}
+
+		if (apiMode === "openai-responses") {
+			const openaiResponsesApi = new OpenaiResponsesApi();
+			const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+			const statefulModelId = requestModelId;
+			const fullInput = openaiResponsesApi.convertMessages(messages, modelConfig);
+
+			const marker = findLastOpenAIResponsesStatefulMarker(statefulModelId, messages);
+			let deltaInput: unknown[] | null = null;
+			if (marker && marker.index >= 0 && marker.index < messages.length - 1) {
+				const deltaMessages = messages.slice(marker.index + 1);
+				const converted = openaiResponsesApi.convertMessages(deltaMessages, modelConfig);
+				if (converted.length > 0) {
+					deltaInput = converted;
+				}
+			}
+
+			const canUsePreviousResponseId =
+				!!marker?.marker &&
+				!this._openaiResponsesPreviousResponseIdUnsupportedBaseUrls.has(normalizedBaseUrl) &&
+				Array.isArray(deltaInput) &&
+				deltaInput.length > 0;
+
+			const input = canUsePreviousResponseId ? deltaInput : fullInput;
+			let requestBody: Record<string, unknown> = {
+				model: requestModelId,
+				input,
+				stream: true,
+			};
+			requestBody = openaiResponsesApi.prepareRequestBody(requestBody, userModel, options);
+			if (routingInstruction) {
+				requestBody.instructions =
+					typeof requestBody.instructions === "string" && requestBody.instructions.trim()
+						? `${String(requestBody.instructions)}\n\n${routingInstruction}`
+						: routingInstruction;
+			}
+			const url = `${normalizedBaseUrl}/responses`;
+
+			let addedPreviousResponseId = false;
+			if (requestBody.previous_response_id !== undefined) {
+				requestBody.input = fullInput;
+			} else if (canUsePreviousResponseId && marker) {
+				requestBody.previous_response_id = marker.marker;
+				addedPreviousResponseId = true;
+			}
+
+			const sendRequest = async (body: Record<string, unknown>) =>
+				await executeWithRetry(async () => {
+					const res = await fetch(url, {
+						method: "POST",
+						headers: requestHeaders,
+						body: JSON.stringify(body),
+					});
+
+					if (!res.ok) {
+						const errorText = await res.text();
+						const error = new Error(
+							`Responses API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+						);
+						(error as { status?: number; errorText?: string }).status = res.status;
+						(error as { status?: number; errorText?: string }).errorText = errorText;
+						throw error;
+					}
+
+					return res;
+				}, retryConfig);
+
+			let response: Response;
+			try {
+				response = await sendRequest(requestBody);
+			} catch (err) {
+				const status = (err as { status?: unknown })?.status;
+				const shouldFallback =
+					addedPreviousResponseId && typeof status === "number" && status >= 400 && status < 500 && status !== 429;
+				if (!shouldFallback) {
+					throw err;
+				}
+
+				this._openaiResponsesPreviousResponseIdUnsupportedBaseUrls.add(normalizedBaseUrl);
+
+				let fallbackBody: Record<string, unknown> = {
+					model: requestModelId,
+					input: fullInput,
+					stream: true,
+				};
+				fallbackBody = openaiResponsesApi.prepareRequestBody(fallbackBody, userModel, options);
+				if (routingInstruction) {
+					fallbackBody.instructions =
+						typeof fallbackBody.instructions === "string" && fallbackBody.instructions.trim()
+							? `${String(fallbackBody.instructions)}\n\n${routingInstruction}`
+							: routingInstruction;
+				}
+				delete fallbackBody.previous_response_id;
+				response = await sendRequest(fallbackBody);
+			}
+
+			if (!response.body) {
+				throw new Error("No response body from Responses API");
+			}
+			await openaiResponsesApi.processStreamingResponse(response.body, progress, token);
+
+			const responseId = openaiResponsesApi.responseId;
+			if (responseId) {
+				progress.report(createOpenAIResponsesStatefulMarkerPart(statefulModelId, responseId));
+			}
+			return;
+		}
+
+		if (apiMode === "gemini") {
+			const geminiApi = new GeminiApi(this._geminiToolCallMetaByCallId);
+			const geminiMessages = geminiApi.convertMessages(messages, modelConfig);
+
+			const systemParts: string[] = [];
+			const contents: GeminiGenerateContentRequest["contents"] = [];
+			for (const msg of geminiMessages) {
+				if (msg.role === "system") {
+					const text = msg.parts
+						.map((part) =>
+							part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string"
+								? String((part as { text: string }).text)
+								: ""
+						)
+						.join("")
+						.trim();
+					if (text) {
+						systemParts.push(text);
+					}
+					continue;
+				}
+				contents.push({ role: msg.role, parts: msg.parts });
+			}
+			if (routingInstruction) {
+				systemParts.push(routingInstruction);
+			}
+
+			let requestBody: GeminiGenerateContentRequest = {
+				contents,
+			};
+			if (systemParts.length > 0) {
+				requestBody.systemInstruction = { role: "user", parts: [{ text: systemParts.join("\n") }] };
+			}
+			requestBody = geminiApi.prepareRequestBody(requestBody, userModel, options);
+
+			const url = buildGeminiGenerateContentUrl(baseUrl, requestModelId, true);
+			if (!url) {
+				throw new Error("Invalid Gemini base URL configuration.");
+			}
+
+			const response = await executeWithRetry(async () => {
+				const res = await fetch(url, {
+					method: "POST",
+					headers: requestHeaders,
+					body: JSON.stringify(requestBody),
+				});
+
+				if (!res.ok) {
+					const errorText = await res.text();
+					console.error("[Gemini Provider] Gemini API error response", errorText);
+					throw new Error(
+						`Gemini API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+					);
+				}
+
+				return res;
+			}, retryConfig);
+
+			if (!response.body) {
+				throw new Error("No response body from Gemini API");
+			}
+			await geminiApi.processStreamingResponse(response.body, progress, token);
+			return;
+		}
+
+		const openaiApi = new OpenaiApi();
+		const openaiMessages = openaiApi.convertMessages(messages, modelConfig);
+		if (routingInstruction) {
+			openaiMessages.unshift({
+				role: "system",
+				content: routingInstruction,
+			});
+		}
+
+		let requestBody: Record<string, unknown> = {
+			model: requestModelId,
+			messages: openaiMessages,
+			stream: true,
+			stream_options: { include_usage: true },
+		};
+		requestBody = openaiApi.prepareRequestBody(requestBody, userModel, options);
+
+		const url = `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
+		const response = await executeWithRetry(async () => {
+			const res = await fetch(url, {
+				method: "POST",
+				headers: requestHeaders,
+				body: JSON.stringify(requestBody),
+			});
+
+			if (!res.ok) {
+				const errorText = await res.text();
+				console.error("[OAI Compatible Model Provider] OAI Compatible API error response", errorText);
+				throw new Error(
+					`OAI Compatible API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+				);
+			}
+
+			return res;
+		}, retryConfig);
+
+		if (!response.body) {
+			throw new Error("No response body from OAI Compatible API");
+		}
+		await openaiApi.processStreamingResponse(response.body, progress, token);
 	}
 
 	/**
@@ -516,7 +668,10 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	}
 }
 
-type OpenAIResponsesStatefulMarkerLocation = { marker: string; index: number };
+interface OpenAIResponsesStatefulMarkerLocation {
+	marker: string;
+	index: number;
+}
 
 function createOpenAIResponsesStatefulMarkerPart(modelId: string, marker: string): vscode.LanguageModelDataPart {
 	const payload = `${modelId}\\${marker}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,15 @@ export interface HFArchitecture {
 	output_modalities?: string[];
 }
 
+export interface FallbackModelRef {
+	id?: string;
+	modelId?: string;
+	configId?: string;
+	owned_by?: string;
+	provider?: string;
+	provide?: string;
+}
+
 export interface HFModelItem {
 	id: string;
 	object?: string;
@@ -29,6 +38,7 @@ export interface HFModelItem {
 	architecture?: HFArchitecture;
 	context_length?: number;
 	vision?: boolean;
+	fallbacks?: FallbackModelRef[];
 	max_tokens?: number;
 	// OpenAI new standard parameter
 	max_completion_tokens?: number;
@@ -139,6 +149,13 @@ export interface RetryConfig {
 	interval_ms?: number;
 	status_codes?: number[];
 }
+
+export type RuntimeResponsePart =
+	| import("vscode").LanguageModelResponsePart2
+	| import("vscode").LanguageModelTextPart
+	| import("vscode").LanguageModelDataPart
+	| import("vscode").LanguageModelThinkingPart
+	| import("vscode").LanguageModelToolCallPart;
 
 /** Supports API mode. */
 export type HFApiMode = "openai" | "openai-responses" | "ollama" | "anthropic" | "gemini";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import type { HFModelItem, RetryConfig } from "./types";
+import type { FallbackModelRef, HFModelItem, RetryConfig } from "./types";
 import { OpenAIFunctionToolDef } from "./openai/openaiTypes";
 
 const RETRY_MAX_ATTEMPTS = 3;
@@ -19,7 +19,32 @@ const networkErrorPatterns = [
 	"TIMEOUT",
 	"network error",
 	"NetworkError",
+	"rate limit",
+	"rate_limit",
+	"too many requests",
+	"quota",
+	"insufficient_quota",
+	"resource_exhausted",
+	"RESOURCE_EXHAUSTED",
+	"exceeded your current quota",
+	"usage limit",
+	"overloaded",
 ];
+
+export function buildConfiguredModelId(modelId: string, configId?: string): string {
+	return configId ? `${modelId}::${configId}` : modelId;
+}
+
+export function buildResolvedModelKey(provider: string | undefined, modelId: string, configId?: string): string {
+	const configuredModelId = buildConfiguredModelId(modelId, configId);
+	return provider ? `${provider}|${configuredModelId}` : configuredModelId;
+}
+
+interface ParsedFallbackRef {
+	provider?: string;
+	modelId: string;
+	configId?: string;
+}
 
 // Model ID parsing helper
 export interface ParsedModelId {
@@ -43,6 +68,70 @@ export function getModelProviderId(model: unknown): string {
 	);
 }
 
+export function parseFallbackRefString(value: string): ParsedFallbackRef | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+
+	const providerSeparator = trimmed.indexOf("|");
+	const provider = providerSeparator >= 0 ? trimmed.slice(0, providerSeparator).trim() : "";
+	const modelRef = providerSeparator >= 0 ? trimmed.slice(providerSeparator + 1).trim() : trimmed;
+	const parsedModel = parseModelId(modelRef);
+	if (!parsedModel.baseId) {
+		return undefined;
+	}
+
+	return {
+		provider: provider || undefined,
+		modelId: parsedModel.baseId,
+		configId: parsedModel.configId,
+	};
+}
+
+export function normalizeFallbackRefs(fallbacks: unknown): FallbackModelRef[] {
+	const list = Array.isArray(fallbacks) ? fallbacks : [];
+	const out: FallbackModelRef[] = [];
+
+	for (const item of list) {
+		if (typeof item === "string") {
+			const parsed = parseFallbackRefString(item);
+			if (!parsed) {
+				continue;
+			}
+			out.push({ modelId: parsed.modelId, configId: parsed.configId, owned_by: parsed.provider });
+			continue;
+		}
+
+		if (!item || typeof item !== "object") {
+			continue;
+		}
+
+		const raw = item as Record<string, unknown>;
+		const rawModelId =
+			typeof raw.id === "string"
+				? raw.id.trim()
+				: typeof raw.modelId === "string"
+					? raw.modelId.trim()
+					: "";
+		const parsed = parseFallbackRefString(rawModelId);
+		const configId = typeof raw.configId === "string" ? raw.configId.trim() : parsed?.configId;
+		const provider = getModelProviderId(item) || parsed?.provider || undefined;
+
+		if (!parsed?.modelId) {
+			continue;
+		}
+
+		out.push({
+			modelId: parsed.modelId,
+			configId: configId || undefined,
+			owned_by: provider,
+		});
+	}
+
+	return out;
+}
+
 export function normalizeUserModels(models: unknown): HFModelItem[] {
 	const list = Array.isArray(models) ? models : [];
 	const out: HFModelItem[] = [];
@@ -51,7 +140,11 @@ export function normalizeUserModels(models: unknown): HFModelItem[] {
 			continue;
 		}
 		const provider = getModelProviderId(item);
-		out.push({ ...(item as HFModelItem), owned_by: provider });
+		out.push({
+			...(item as HFModelItem),
+			owned_by: provider,
+			fallbacks: normalizeFallbackRefs((item as { fallbacks?: unknown }).fallbacks),
+		});
 	}
 	return out;
 }
@@ -270,6 +363,19 @@ export function createRetryConfig(): RetryConfig {
 	};
 }
 
+export function getRetryableStatusCodes(retryConfig: RetryConfig, extraStatusCodes: number[] = []): number[] {
+	return retryConfig.status_codes
+		? [...new Set([...RETRYABLE_STATUS_CODES, ...retryConfig.status_codes, ...extraStatusCodes])]
+		: [...new Set([...RETRYABLE_STATUS_CODES, ...extraStatusCodes])];
+}
+
+export function isRetryableError(error: Error, retryConfig: RetryConfig, extraStatusCodes: number[] = []): boolean {
+	const retryableStatusCodes = getRetryableStatusCodes(retryConfig, extraStatusCodes);
+	const isRetryableStatusError = retryableStatusCodes.some((code) => error.message.includes(`[${code}]`));
+	const isRetryableNetworkError = networkErrorPatterns.some((pattern) => error.message.includes(pattern));
+	return isRetryableStatusError || isRetryableNetworkError;
+}
+
 /**
  * Execute a function with retry logic for rate limiting.
  * @param fn The async function to execute
@@ -284,10 +390,6 @@ export async function executeWithRetry<T>(fn: () => Promise<T>, retryConfig: Ret
 
 	const maxAttempts = retryConfig.max_attempts ?? RETRY_MAX_ATTEMPTS;
 	const intervalMs = retryConfig.interval_ms ?? RETRY_INTERVAL_MS;
-	// Merge user-configured status codes with default ones, removing duplicates
-	const retryableStatusCodes = retryConfig.status_codes
-		? [...new Set([...RETRYABLE_STATUS_CODES, ...retryConfig.status_codes])]
-		: RETRYABLE_STATUS_CODES;
 	let lastError: Error | undefined;
 
 	for (let attempt = 0; attempt <= maxAttempts; attempt++) {
@@ -296,13 +398,7 @@ export async function executeWithRetry<T>(fn: () => Promise<T>, retryConfig: Ret
 		} catch (error) {
 			lastError = error instanceof Error ? error : new Error(String(error));
 
-			// Check if error is retryable based on status codes
-			const isRetryableStatusError = retryableStatusCodes.some((code) => lastError?.message.includes(`[${code}]`));
-			// Check if error is retryable based on network error patterns
-			const isRetryableNetworkError = networkErrorPatterns.some((pattern) => lastError?.message.includes(pattern));
-			const isRetryableError = isRetryableStatusError || isRetryableNetworkError;
-
-			if (!isRetryableError || attempt === maxAttempts) {
+			if (!isRetryableError(lastError, retryConfig) || attempt === maxAttempts) {
 				throw lastError;
 			}
 


### PR DESCRIPTION
## Summary

This PR adds configurable fallback chain support for OAI-compatible model endpoints.

It extends model configuration with ordered fallback targets, resolves fallback routes across duplicate model IDs, and improves runtime failover behavior so requests can continue through a secondary provider/model when the primary route fails.

## What changed

- add `oaicopilot.models[*].fallbacks` configuration schema
- add fallback reference normalization helpers for:
  - `modelId`
  - `modelId::configId`
  - `provider|modelId`
  - object references with `modelId` / `configId` / `owned_by`
- add a dedicated fallback executor to orchestrate sequential failover
- preserve clearer model labels in the picker when the same model ID exists under multiple providers
- detect ambiguous fallback targets and require explicit provider qualification when needed

## Runtime behavior

- fail over from the primary route to configured fallbacks on retryable upstream failures
- include additional fallback-eligible cases such as `404` / `405` and common quota / rate-limit / resource exhaustion errors
- escalate streamed provider-side error events into real exceptions so mid-stream failures can trigger fallback
- buffer streamed output per attempt and replay only the successful attempt, preventing partial failed output from leaking into the chat
- inject routing instructions so the fallback model identifies the actual routed model/provider
- ask the fallback model to briefly note rerouting in the final user-facing response

## Validation

- `npm run compile`
- `npm test`
- local VS Code validation with isolated user/extensions directories
- manual checks around:
  - broken endpoint fallback
  - duplicate model IDs across providers
  - rerouted model identity handling

## Notes

- local VSIX and isolated VS Code test artifacts are excluded from packaging and git tracking