### PR TITLE
Enhance reasoning handling in openaiApi.ts

### DIFF
--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -339,6 +339,7 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 			let maybeThinking =
 				(choice as Record<string, unknown> | undefined)?.thinking ??
 				(deltaObj as Record<string, unknown> | undefined)?.thinking ??
+				(deltaObj as Record<string, unknown> | undefined)?.reasoning ??
 				(deltaObj as Record<string, unknown> | undefined)?.reasoning_content;
 
 			// OpenRouter/Claude reasoning_details array handling (new)


### PR DESCRIPTION
According to https://developers.openai.com/cookbook/articles/gpt-oss/handle-raw-cot#chat-completions-api and https://github.com/vllm-project/vllm/issues/27755 This fix enables recent vLLM instance reasoning tokens to be correctly displayed in vscode copilot.