### PR TITLE
Fix preserved reasoning replay for glm-5.1 and OpenAI-compatible chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ To use this feature:
 2. Each configuration with the same `id` must have a unique `configId`
 3. The model will appear as separate entries in the VS Code model picker
 
+`configId` only selects which configuration variant is used. Whether assistant
+`reasoning_content` is sent or restored is controlled by the model parameters of that
+variant, such as `include_reasoning_in_request` for OpenAI-compatible
+`/chat/completions` providers.
+
 ### Settings Example
 
 ```json
@@ -264,7 +269,7 @@ To use this feature:
 ]
 ```
 
-In this example, you'll have three different configurations of the glm-4.6 model available in VS Code:
+In this example, you'll have two different configurations of the glm-4.6 model available in VS Code:
 - `glm-4.6::thinking` - use GLM-4.6 with thinking
 - `glm-4.6::no-thinking` - use GLM-4.6 without thinking
 
@@ -364,6 +369,32 @@ The `extra` field allows you to add arbitrary parameters to the API request body
 ### Show thinking in Copilot
 These are provider-specific parameters that can make Copilot show a **Thinking** block (if the provider/model supports it).
 
+#### OpenAI-compatible Chat Completions
+Use `apiMode: "openai"` together with `include_reasoning_in_request: true` for providers
+that expect `reasoning_content` on replayed assistant turns (for example GLM and some
+DeepSeek-compatible gateways):
+
+```json
+{
+    "id": "glm-4.6",
+    "owned_by": "zai",
+    "baseUrl": "https://open.bigmodel.cn/api/paas/v4",
+    "apiMode": "openai",
+    "thinking": {
+        "type": "enabled"
+    },
+    "include_reasoning_in_request": true
+}
+```
+
+Notes:
+- This switch applies only to OpenAI-compatible `/chat/completions` requests.
+- The extension persists assistant reasoning locally and replays it on later turns so
+    providers that rely on `reasoning_content` can preserve thinking across turns and
+    VS Code restarts.
+- If `include_reasoning_in_request` is `false`, the extension will not restore or send
+    `reasoning_content` for that config variant.
+
 #### OpenAI Responses
 Use `apiMode: "openai-responses"` and set the reasoning summary mode:
 
@@ -446,10 +477,27 @@ All parameters support individual configuration for different models, providing 
 - `reasoning_effort`: Reasoning effort level (OpenAI reasoning configuration)
 - `headers`: Custom HTTP headers to be sent with every request to this model's provider (e.g., `{"X-API-Version": "v1", "X-Custom-Header": "value"}`). These headers will be merged with the default headers (Authorization, Content-Type, User-Agent)
 - `extra`: Extra request body parameters.
-- `include_reasoning_in_request`: Whether to include reasoning_content in assistant messages sent to the API. Supports deepseek-v3.2 and similar models.
+- `include_reasoning_in_request`: Whether to include `reasoning_content` in assistant messages sent to OpenAI-compatible `/chat/completions` APIs. When enabled, the extension also restores locally persisted reasoning for replayed assistant turns. Supports deepseek-v3.2, GLM, and similar providers.
 - `apiMode`: API mode: 'openai' (Default) for API (/chat/completions), 'openai-responses' for API (/responses), 'ollama' for API (/api/chat), 'anthropic' for API (/v1/messages), 'gemini' for API (/v1beta/models/{model}:streamGenerateContent?alt=sse).
 - `delay`: Model-specific delay in milliseconds between consecutive requests. If not specified, falls back to global `oaicopilot.delay` configuration.
 - `useForCommitGeneration`: Whether to be used for Git commit message generation. Not supports gemini apiMode.
+
+## Development Verification
+
+If you modify reasoning replay or tool serialization behavior, run these checks before
+submitting:
+
+```bash
+npm run compile
+node scripts/verify_persistent_reasoning_restart.mjs
+node scripts/verify_tool_reasoning_shape.mjs
+npm run verify:reasoning-tools
+```
+
+Coverage:
+- `verify_persistent_reasoning_restart.mjs`: validates persisted reasoning replay across turns and restart boundaries for `/chat/completions`.
+- `verify_tool_reasoning_shape.mjs`: validates request serialization for assistant text, `reasoning_content`, `tool_calls`, and tool results.
+- `verify_tool_reasoning_replay.mjs`: validates reasoning replay together with tool calls, and ensures configs with `include_reasoning_in_request=false` do not leak `reasoning_content`.
 
 ## Thanks to
 

--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ All parameters support individual configuration for different models, providing 
 - `thinking`: Thinking configuration for Zai provider
   - `type`: Set to 'enabled' to enable thinking, 'disabled' to disable thinking
 - `reasoning_effort`: Reasoning effort level (OpenAI reasoning configuration)
+  - Some OpenAI-compatible providers support additional values such as `xhigh` (for example, DeepSeek maps `xhigh` to `max`)
 - `headers`: Custom HTTP headers to be sent with every request to this model's provider (e.g., `{"X-API-Version": "v1", "X-Custom-Header": "value"}`). These headers will be merged with the default headers (Authorization, Content-Type, User-Agent)
 - `extra`: Extra request body parameters.
 - `include_reasoning_in_request`: Whether to include `reasoning_content` in assistant messages sent to OpenAI-compatible `/chat/completions` APIs. When enabled, the extension also restores locally persisted reasoning for replayed assistant turns. Supports deepseek-v3.2, GLM, and similar providers.

--- a/assets/configView/configView.html
+++ b/assets/configView/configView.html
@@ -357,6 +357,7 @@
 									<div class="field-description">Include "reasoning_effort" in request body.</div>
 									<select id="modelReasoningEffort" class="model-input">
 										<option value=""></option>
+										<option value="xhigh">XHigh</option>
 										<option value="high">High</option>
 										<option value="medium">Medium</option>
 										<option value="low">Low</option>

--- a/package.json
+++ b/package.json
@@ -455,7 +455,8 @@
 		"format": "prettier --write .",
 		"watch": "tsc -watch -p ./",
 		"test": "npm run compile && vscode-test",
-		"build": "npx @vscode/vsce package -o extension.vsix"
+		"build": "npx @vscode/vsce package -o extension.vsix",
+		"verify:reasoning-tools": "node scripts/verify_tool_reasoning_replay.mjs"
 	},
 	"dependencies": {
 		"@microsoft/tiktokenizer": "^1.0.10"

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
 								"type": "string",
 								"default": "medium",
 								"enum": [
+									"xhigh",
 									"high",
 									"medium",
 									"low",

--- a/parse_debug_log.py
+++ b/parse_debug_log.py
@@ -1,0 +1,106 @@
+import json
+import re
+import sys
+
+def parse_log(file_path):
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    # Find the latest request-preflight block
+    # Matches: === 2026-04-27T04:24:46.824Z request-preflight ===
+    marker_pattern = r'=== .*? request-preflight ==='
+    preflight_headers = list(re.finditer(marker_pattern, content))
+    
+    if not preflight_headers:
+        print("No request-preflight block found.")
+        return
+
+    latest_header = preflight_headers[-1]
+    start_pos = latest_header.end()
+    
+    # The JSON starts after the header and ends at the next marker or EOF
+    next_marker = re.search(r'=== .*? ===', content[start_pos:])
+    if next_marker:
+        preflight_json_str = content[start_pos : start_pos + next_marker.start()].strip()
+    else:
+        preflight_json_str = content[start_pos:].strip()
+
+    try:
+        preflight_data = json.loads(preflight_json_str)
+    except json.JSONDecodeError as e:
+        print(f"Error decoding preflight JSON: {e}")
+        # Try to find the closing brace index
+        last_brace = preflight_json_str.rfind('}')
+        if last_brace != -1:
+             try:
+                 preflight_data = json.loads(preflight_json_str[:last_brace+1])
+             except:
+                 return
+        else:
+            return
+
+    # Look for the completion/response block
+    # Since grep failed, maybe it's "completion" or similar
+    comp_header_match = re.search(r'=== .*? (completion|response) ===', content[start_pos:])
+    completion_data = None
+    if comp_header_match:
+        comp_start = start_pos + comp_header_match.end()
+        # Find next marker or EOF
+        next_m = re.search(r'=== .*? ===', content[comp_start:])
+        if next_m:
+            comp_json_str = content[comp_start : comp_start + next_m.start()].strip()
+        else:
+            comp_json_str = content[comp_start:].strip()
+        
+        try:
+            completion_data = json.loads(comp_json_str)
+        except:
+            pass
+
+    # Extract info
+    model = preflight_data.get('model') or preflight_data.get('modelId')
+    api_mode = preflight_data.get('apiMode')
+    
+    # Original Messages
+    orig_messages = preflight_data.get('originalMessages', [])
+    last_user_msg = ""
+    for msg in reversed(orig_messages):
+        if msg.get('role') == 'user':
+            last_user_msg = msg.get('text', '')
+            break
+            
+    orig_assistant = [{"text": m.get('text'), "thinking": m.get('thinking')} for m in orig_messages if m.get('role') == 'assistant']
+    
+    # Restored Messages
+    rest_messages = preflight_data.get('restoredMessages', [])
+    rest_assistant = [{"text": m.get('text'), "thinking": m.get('thinking')} for m in rest_messages if m.get('role') == 'assistant']
+    
+    # OpenAI Messages
+    openai_messages = preflight_data.get('openaiMessages') or preflight_data.get('requestBody', {}).get('messages', [])
+    openai_assistant = [{"content": m.get('content'), "reasoning_content": m.get('reasoning_content')} for m in openai_messages if m.get('role') == 'assistant']
+    
+    # Completion
+    comp_content = None
+    comp_reasoning = None
+    if completion_data:
+        choices = completion_data.get('choices', [])
+        if choices:
+            msg = choices[0].get('message', {})
+            comp_content = msg.get('content')
+            comp_reasoning = msg.get('reasoning_content')
+
+    # Booleans
+    any_restored_thinking = any(m.get('thinking') is not None and m.get('thinking') != "" for m in rest_assistant)
+    any_request_reasoning = any(m.get('reasoning_content') is not None and m.get('reasoning_content') != "" for m in openai_assistant)
+
+    print(f"Model/ApiMode: {model} / {api_mode}")
+    print(f"Last User Message: {last_user_msg!r}")
+    print(f"Original Assistant: {json.dumps(orig_assistant)}")
+    print(f"Restored Assistant: {json.dumps(rest_assistant)}")
+    print(f"OpenAI/RequestBody Assistant: {json.dumps(openai_assistant)}")
+    print(f"Final Completion: content={json.dumps(comp_content)}, reasoning_content={json.dumps(comp_reasoning)}")
+    print(f"Any restored thinking: {any_restored_thinking}")
+    print(f"Any request reasoning_content: {any_request_reasoning}")
+
+if __name__ == "__main__":
+    parse_log('/tmp/oaicopilot-deepseek-debug.log')

--- a/parse_logs.py
+++ b/parse_logs.py
@@ -1,0 +1,35 @@
+import sys, json, re
+
+with open("/tmp/log_tail.txt", "r") as f:
+    content = f.read()
+
+events = re.split(r"=== (.*?) request-preflight ===", content)
+results = []
+for i in range(1, len(events), 2):
+    ts = events[i]
+    body = events[i+1]
+    
+    model_id = re.search(r"modelId:\s*\"([^\"]+)\"", body)
+    initiator = re.search(r"requestInitiator:\s*\"([^\"]+)\"", body)
+    conv_id = re.search(r"conversationId:\s*\"([^\"]+)\"", body)
+    api_mode = re.search(r"apiMode:\s*\"([^\"]+)\"", body)
+    
+    m_id = model_id.group(1) if model_id else "N/A"
+    init = initiator.group(1) if initiator else "N/A"
+    c_id = conv_id.group(1) if conv_id else "N/A"
+    am = api_mode.group(1) if api_mode else "N/A"
+    
+    replays = []
+    # Match reasoning_content in history/messages
+    for match in re.finditer(r"reasoning_content:\s*(?:\"([^\"]*)\"|(null|undefined))", body):
+        text = match.group(1)
+        lit = match.group(2)
+        if lit or not text:
+            replays.append("empty")
+        else:
+            replays.append("non-empty")
+            
+    results.append((ts, m_id, init, c_id, am, len(replays), str(replays)))
+
+for r in results[-12:]:
+    print(" | ".join(map(str, r)))

--- a/probe.py
+++ b/probe.py
@@ -1,0 +1,44 @@
+import json
+import urllib.request
+
+def probe(url, messages, api_key="EMPTY"):
+    payload = {
+        "model": "qwen3.6-35b-a3b-fp8",
+        "messages": messages,
+        "temperature": 0
+    }
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {api_key}'
+    }
+    req = urllib.request.Request(url, data=json.dumps(payload).encode('utf-8'), headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as response:
+            res = json.loads(response.read().decode('utf-8'))
+            choice = res['choices'][0]['message']
+            content = choice.get('content', '')
+            reasoning = choice.get('reasoning_content', '')
+            return {"content": content, "reasoning": reasoning}
+    except Exception as e:
+        return {"error": str(e)}
+
+endpoints = ["http://127.0.0.1:8050/v1/chat/completions", "http://127.0.0.1:31080/v1/chat/completions"]
+cases = {
+    "A": [
+        {"role": "assistant", "content": "84729163058472916305", "reasoning_content": "The second number is 39105847263910584726."},
+        {"role": "user", "content": "What is the second number?"}
+    ],
+    "B": [
+        {"role": "assistant", "content": "84729163058472916305"},
+        {"role": "user", "content": "What is the second number?"}
+    ]
+}
+
+results = {}
+for url in endpoints:
+    port = url.split(':')[-1].split('/')[0]
+    for case_label, messages in cases.items():
+        key = f"{port}-{case_label}"
+        results[key] = probe(url, messages)
+
+print(json.dumps(results, indent=2))

--- a/scripts/verify_persistent_reasoning_restart.mjs
+++ b/scripts/verify_persistent_reasoning_restart.mjs
@@ -1,0 +1,261 @@
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+
+class LanguageModelTextPart {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+class LanguageModelThinkingPart {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+class LanguageModelDataPart {
+	constructor(data, mimeType) {
+		this.data = data;
+		this.mimeType = mimeType;
+	}
+}
+
+class LanguageModelToolCallPart {
+	constructor(callId, name, input) {
+		this.callId = callId;
+		this.name = name;
+		this.input = input;
+	}
+}
+
+class ThemeColor {
+	constructor(id) {
+		this.id = id;
+	}
+}
+
+const Uri = {
+	file(fsPath) {
+		return { fsPath };
+	},
+	joinPath(base, ...segments) {
+		return { fsPath: path.join(base.fsPath, ...segments) };
+	},
+};
+
+class MemoryMemento {
+	constructor(seed = new Map()) {
+		this.store = seed;
+	}
+	get(key, defaultValue) {
+		return this.store.has(key) ? this.store.get(key) : defaultValue;
+	}
+	async update(key, value) {
+		this.store.set(key, value);
+	}
+}
+
+const mockVscode = {
+	LanguageModelTextPart,
+	LanguageModelThinkingPart,
+	LanguageModelDataPart,
+	LanguageModelToolCallPart,
+	version: "1.104.0-test",
+	Uri,
+	LanguageModelChatMessageRole: {
+		User: 1,
+		Assistant: 2,
+		System: 3,
+	},
+	LanguageModelChatToolMode: {
+		Required: 1,
+	},
+	ThemeColor,
+	workspace: {
+		getConfiguration() {
+			return {
+				get(key, defaultValue) {
+					if (key === "oaicopilot.models") {
+						return [
+							{
+								id: "glm-5.1",
+								configId: "variant-a",
+								owned_by: "zai",
+								apiMode: "openai",
+								baseUrl: "https://example.invalid/v1",
+								include_reasoning_in_request: true,
+							},
+							{
+								id: "glm-5.1",
+								configId: "variant-b",
+								owned_by: "zai",
+								apiMode: "openai",
+								baseUrl: "https://example.invalid/v1",
+								include_reasoning_in_request: false,
+							},
+						];
+					}
+					if (key === "oaicopilot.delay") {
+						return 0;
+					}
+					return defaultValue;
+				},
+			};
+		},
+	},
+	window: {
+		showInputBox: async () => "",
+	},
+	extensions: {
+		getExtension() {
+			return { packageJSON: { version: "0.3.4-test" } };
+		},
+	},
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+	if (request === "vscode") {
+		return mockVscode;
+	}
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+const originalFetch = globalThis.fetch;
+let originalProcessStreamingResponse;
+
+try {
+	const extensionRoot = path.resolve(__dirname, "..");
+	const outDir = path.resolve(__dirname, "../out");
+	const { TokenizerManager } = require(path.join(outDir, "tokenizer/tokenizerManager.js"));
+	const { HuggingFaceChatModelProvider } = require(path.join(outDir, "provider.js"));
+	const { OpenaiApi } = require(path.join(outDir, "openai/openaiApi.js"));
+	TokenizerManager.initialize(extensionRoot);
+
+	const sharedStore = new Map();
+	const firstState = new MemoryMemento(sharedStore);
+	const secondState = new MemoryMemento(sharedStore);
+	const statusBarItem = { text: "", tooltip: "", backgroundColor: undefined, show() {} };
+	const secrets = { get: async () => "dummy-api-key", store: async () => {}, delete: async () => {} };
+	const model = { id: "glm-5.1::variant-a", maxInputTokens: 100000, maxOutputTokens: 4096 };
+	const noReasoningModel = { id: "glm-5.1::variant-b", maxInputTokens: 100000, maxOutputTokens: 4096 };
+	const token = { isCancellationRequested: false };
+	const USER = mockVscode.LanguageModelChatMessageRole.User;
+	const ASSISTANT = mockVscode.LanguageModelChatMessageRole.Assistant;
+	const SYSTEM = mockVscode.LanguageModelChatMessageRole.System;
+
+	const firstTurnMessages = [
+		{ role: SYSTEM, content: [new LanguageModelTextPart("You are an assistant")] },
+		{ role: SYSTEM, content: [new LanguageModelTextPart("Extra transient instruction")] },
+		{ role: USER, content: [new LanguageModelTextPart("Think first and reply READY only")] },
+	];
+
+	const secondTurnMessages = [
+		{ role: SYSTEM, content: [new LanguageModelTextPart("You are an assistant")] },
+		{ role: USER, content: [new LanguageModelTextPart("Think first and reply READY only")] },
+		{ role: ASSISTANT, content: [new LanguageModelTextPart("READY")] },
+		{ role: USER, content: [new LanguageModelTextPart("What values did you pick?")] },
+	];
+
+	const requestBodies = [];
+	globalThis.fetch = async (_url, init) => {
+		requestBodies.push(JSON.parse(init.body));
+		return { ok: true, body: {} };
+	};
+
+	originalProcessStreamingResponse = OpenaiApi.prototype.processStreamingResponse;
+	OpenaiApi.prototype.processStreamingResponse = async function (_body, progress) {
+		progress.report(new LanguageModelThinkingPart("A=0.30,B=0.25,C=0.20,D=0.15,E=0.10"));
+		progress.report(new LanguageModelTextPart("READY"));
+	};
+
+	const firstProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, firstState);
+	await firstProvider.provideLanguageModelChatResponse(
+		model,
+		firstTurnMessages,
+		{ tools: [], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const secondProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, secondState);
+	await secondProvider.provideLanguageModelChatResponse(
+		model,
+		secondTurnMessages,
+		{ tools: [], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const secondRequest = requestBodies.at(-1);
+	const restoredAssistant = secondRequest.messages.find((message) => message.role === "assistant");
+	if (!restoredAssistant) {
+		throw new Error("Assistant replay message missing from second request");
+	}
+	if (restoredAssistant.content !== "READY") {
+		throw new Error(`Unexpected assistant content replay: ${restoredAssistant.content ?? "<missing>"}`);
+	}
+	if (restoredAssistant.reasoning_content !== "A=0.30,B=0.25,C=0.20,D=0.15,E=0.10") {
+		throw new Error(
+			`Persistent reasoning replay failed: ${restoredAssistant.reasoning_content ?? "<missing>"}`
+		);
+	}
+
+	console.log("Persistent reasoning restart validation passed.");
+	console.log(JSON.stringify(restoredAssistant, null, 2));
+
+	const thirdProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, secondState);
+	await thirdProvider.provideLanguageModelChatResponse(
+		model,
+		secondTurnMessages,
+		{ tools: [], requestInitiator: "other.extension" },
+		{ report() {} },
+		token
+	);
+
+	const thirdRequest = requestBodies.at(-1);
+	const thirdAssistant = thirdRequest.messages.find((message) => message.role === "assistant");
+	if (!thirdAssistant) {
+		throw new Error("Assistant replay message missing from third request");
+	}
+	if (thirdAssistant.reasoning_content !== undefined) {
+		throw new Error("Reasoning unexpectedly leaked across requestInitiator boundaries");
+	}
+
+	console.log("requestInitiator partition validation passed.");
+	console.log(JSON.stringify(thirdAssistant, null, 2));
+
+	const fourthProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, secondState);
+	await fourthProvider.provideLanguageModelChatResponse(
+		noReasoningModel,
+		secondTurnMessages,
+		{ tools: [], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const fourthRequest = requestBodies.at(-1);
+	const fourthAssistant = fourthRequest.messages.find((message) => message.role === "assistant");
+	if (!fourthAssistant) {
+		throw new Error("Assistant replay message missing from fourth request");
+	}
+	if (fourthAssistant.reasoning_content !== undefined) {
+		throw new Error("Reasoning unexpectedly leaked into include_reasoning_in_request=false config variant");
+	}
+
+	console.log("configId variant-b isolation validation passed.");
+	console.log(JSON.stringify(fourthAssistant, null, 2));
+} finally {
+	Module._load = originalLoad;
+	globalThis.fetch = originalFetch;
+	if (originalProcessStreamingResponse) {
+		const outDir = path.resolve(__dirname, "../out");
+		const { OpenaiApi } = require(path.join(outDir, "openai/openaiApi.js"));
+		OpenaiApi.prototype.processStreamingResponse = originalProcessStreamingResponse;
+	}
+}

--- a/scripts/verify_persistent_reasoning_restart.mjs
+++ b/scripts/verify_persistent_reasoning_restart.mjs
@@ -154,13 +154,7 @@ try {
 		{ role: SYSTEM, content: [new LanguageModelTextPart("Extra transient instruction")] },
 		{ role: USER, content: [new LanguageModelTextPart("Think first and reply READY only")] },
 	];
-
-	const secondTurnMessages = [
-		{ role: SYSTEM, content: [new LanguageModelTextPart("You are an assistant")] },
-		{ role: USER, content: [new LanguageModelTextPart("Think first and reply READY only")] },
-		{ role: ASSISTANT, content: [new LanguageModelTextPart("READY")] },
-		{ role: USER, content: [new LanguageModelTextPart("What values did you pick?")] },
-	];
+	const firstTurnResponseParts = [];
 
 	const requestBodies = [];
 	globalThis.fetch = async (_url, init) => {
@@ -179,9 +173,28 @@ try {
 		model,
 		firstTurnMessages,
 		{ tools: [], requestInitiator: "github.copilot-chat" },
-		{ report() {} },
+		{
+			report(part) {
+				firstTurnResponseParts.push(part);
+			},
+		},
 		token
 	);
+
+	const replayedAssistant = {
+		role: ASSISTANT,
+		content: [
+			new LanguageModelTextPart("READY"),
+			...firstTurnResponseParts.filter((part) => part instanceof LanguageModelDataPart),
+		],
+	};
+
+	const secondTurnMessages = [
+		{ role: SYSTEM, content: [new LanguageModelTextPart("You are an assistant")] },
+		{ role: USER, content: [new LanguageModelTextPart("Think first and reply READY only")] },
+		replayedAssistant,
+		{ role: USER, content: [new LanguageModelTextPart("What values did you pick?")] },
+	];
 
 	const secondProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, secondState);
 	await secondProvider.provideLanguageModelChatResponse(
@@ -209,6 +222,60 @@ try {
 	console.log("Persistent reasoning restart validation passed.");
 	console.log(JSON.stringify(restoredAssistant, null, 2));
 
+	const markerOnlyState = new MemoryMemento(new Map());
+	const markerOnlyProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, markerOnlyState);
+	await markerOnlyProvider.provideLanguageModelChatResponse(
+		model,
+		secondTurnMessages,
+		{ tools: [], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const markerOnlyRequest = requestBodies.at(-1);
+	const markerOnlyAssistant = markerOnlyRequest.messages.find((message) => message.role === "assistant");
+	if (!markerOnlyAssistant) {
+		throw new Error("Assistant replay message missing from marker-only request");
+	}
+	if (markerOnlyAssistant.reasoning_content !== "A=0.30,B=0.25,C=0.20,D=0.15,E=0.10") {
+		throw new Error(
+			`Reasoning marker replay failed without cache: ${markerOnlyAssistant.reasoning_content ?? "<missing>"}`
+		);
+	}
+
+	console.log("Reasoning marker replay validation passed.");
+	console.log(JSON.stringify(markerOnlyAssistant, null, 2));
+
+	const markerStrippedMessages = [
+		{ role: SYSTEM, content: [new LanguageModelTextPart("You are an assistant")] },
+		{ role: USER, content: [new LanguageModelTextPart("Think first and reply READY only")] },
+		{ role: ASSISTANT, content: [new LanguageModelTextPart("READY")] },
+		{ role: USER, content: [new LanguageModelTextPart("What values did you pick?")] },
+	];
+
+	const markerStrippedProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, secondState);
+	await markerStrippedProvider.provideLanguageModelChatResponse(
+		model,
+		markerStrippedMessages,
+		{ tools: [], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const markerStrippedRequest = requestBodies.at(-1);
+	const markerStrippedAssistant = markerStrippedRequest.messages.find((message) => message.role === "assistant");
+	if (!markerStrippedAssistant) {
+		throw new Error("Assistant replay message missing from marker-stripped request");
+	}
+	if (markerStrippedAssistant.reasoning_content !== "A=0.30,B=0.25,C=0.20,D=0.15,E=0.10") {
+		throw new Error(
+			`Legacy reasoning fallback failed after marker stripping: ${markerStrippedAssistant.reasoning_content ?? "<missing>"}`
+		);
+	}
+
+	console.log("Legacy reasoning fallback validation passed.");
+	console.log(JSON.stringify(markerStrippedAssistant, null, 2));
+
 	const thirdProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, secondState);
 	await thirdProvider.provideLanguageModelChatResponse(
 		model,
@@ -223,8 +290,10 @@ try {
 	if (!thirdAssistant) {
 		throw new Error("Assistant replay message missing from third request");
 	}
-	if (thirdAssistant.reasoning_content !== undefined) {
-		throw new Error("Reasoning unexpectedly leaked across requestInitiator boundaries");
+	if (thirdAssistant.reasoning_content !== "") {
+		throw new Error(
+			`Missing reasoning should serialize as empty string across requestInitiator boundaries, got ${thirdAssistant.reasoning_content ?? "<missing>"}`
+		);
 	}
 
 	console.log("requestInitiator partition validation passed.");

--- a/scripts/verify_tool_reasoning_replay.mjs
+++ b/scripts/verify_tool_reasoning_replay.mjs
@@ -1,0 +1,305 @@
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+
+class LanguageModelTextPart {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+class LanguageModelThinkingPart {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+class LanguageModelDataPart {
+	constructor(data, mimeType) {
+		this.data = data;
+		this.mimeType = mimeType;
+	}
+}
+
+class LanguageModelToolCallPart {
+	constructor(callId, name, input) {
+		this.callId = callId;
+		this.name = name;
+		this.input = input;
+	}
+}
+
+class LanguageModelToolResultPart {
+	constructor(callId, content) {
+		this.callId = callId;
+		this.content = content;
+	}
+	toString() {
+		return this.content
+			.map((part) => (part instanceof LanguageModelTextPart ? part.value : ""))
+			.join("");
+	}
+	async asString() {
+		return this.toString();
+	}
+}
+
+class ThemeColor {
+	constructor(id) {
+		this.id = id;
+	}
+}
+
+const Uri = {
+	file(fsPath) {
+		return { fsPath };
+	},
+	joinPath(base, ...segments) {
+		return { fsPath: path.join(base.fsPath, ...segments) };
+	},
+};
+
+class MemoryMemento {
+	constructor(seed = new Map()) {
+		this.store = seed;
+	}
+	get(key, defaultValue) {
+		return this.store.has(key) ? this.store.get(key) : defaultValue;
+	}
+	async update(key, value) {
+		this.store.set(key, value);
+	}
+}
+
+const mockVscode = {
+	LanguageModelTextPart,
+	LanguageModelThinkingPart,
+	LanguageModelDataPart,
+	LanguageModelToolCallPart,
+	LanguageModelToolResultPart,
+	version: "1.104.0-test",
+	Uri,
+	LanguageModelChatMessageRole: {
+		User: 1,
+		Assistant: 2,
+		System: 3,
+	},
+	LanguageModelChatToolMode: {
+		Required: 1,
+	},
+	ThemeColor,
+	workspace: {
+		getConfiguration() {
+			return {
+				get(key, defaultValue) {
+					if (key === "oaicopilot.models") {
+						return [
+							{
+								id: "glm-5.1",
+								configId: "variant-a",
+								owned_by: "zai",
+								apiMode: "openai",
+								baseUrl: "https://example.invalid/v1",
+								include_reasoning_in_request: true,
+							},
+							{
+								id: "glm-5.1",
+								configId: "variant-b",
+								owned_by: "zai",
+								apiMode: "openai",
+								baseUrl: "https://example.invalid/v1",
+								include_reasoning_in_request: false,
+							},
+						];
+					}
+					if (key === "oaicopilot.delay") {
+						return 0;
+					}
+					return defaultValue;
+				},
+			};
+		},
+	},
+	window: {
+		showInputBox: async () => "",
+	},
+	extensions: {
+		getExtension() {
+			return { packageJSON: { version: "0.3.4-test" } };
+		},
+	},
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+	if (request === "vscode") {
+		return mockVscode;
+	}
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+const originalFetch = globalThis.fetch;
+let originalProcessStreamingResponse;
+
+try {
+	const extensionRoot = path.resolve(__dirname, "..");
+	const outDir = path.resolve(__dirname, "../out");
+	const { TokenizerManager } = require(path.join(outDir, "tokenizer/tokenizerManager.js"));
+	const { HuggingFaceChatModelProvider } = require(path.join(outDir, "provider.js"));
+	const { OpenaiApi } = require(path.join(outDir, "openai/openaiApi.js"));
+	TokenizerManager.initialize(extensionRoot);
+
+	const sharedStore = new Map();
+	const reasoningState = new MemoryMemento(sharedStore);
+	const statusBarItem = { text: "", tooltip: "", backgroundColor: undefined, show() {} };
+	const secrets = { get: async () => "dummy-api-key", store: async () => {}, delete: async () => {} };
+	const reasoningOnModel = { id: "glm-5.1::variant-a", maxInputTokens: 100000, maxOutputTokens: 4096 };
+	const reasoningOffModel = { id: "glm-5.1::variant-b", maxInputTokens: 100000, maxOutputTokens: 4096 };
+	const token = { isCancellationRequested: false };
+	const USER = mockVscode.LanguageModelChatMessageRole.User;
+	const SYSTEM = mockVscode.LanguageModelChatMessageRole.System;
+
+	const weatherTool = {
+		name: "get_weather",
+		description: "Get weather information",
+		inputSchema: {
+			type: "object",
+			properties: {
+				city: { type: "string" },
+			},
+			required: ["city"],
+		},
+	};
+
+	const firstTurnMessages = [
+		{ role: SYSTEM, content: [new LanguageModelTextPart("You are an assistant")] },
+		{ role: USER, content: [new LanguageModelTextPart("What's the weather like in Beijing?")] },
+	];
+
+	const replayedAssistant = {
+		role: mockVscode.LanguageModelChatMessageRole.Assistant,
+		content: [
+			new LanguageModelTextPart("I'll check that for you."),
+			new LanguageModelToolCallPart("call_weather_1", "get_weather", { city: "Beijing" }),
+		],
+	};
+
+	const secondTurnMessages = [
+		firstTurnMessages[0],
+		firstTurnMessages[1],
+		replayedAssistant,
+		{
+			role: USER,
+			content: [
+				new LanguageModelToolResultPart("call_weather_1", [
+					new LanguageModelTextPart('{"weather":"Sunny","temp":"25°C"}'),
+				]),
+			],
+		},
+		{ role: USER, content: [new LanguageModelTextPart("Summarize the result.")] },
+	];
+
+	const requestBodies = [];
+	globalThis.fetch = async (_url, init) => {
+		requestBodies.push(JSON.parse(init.body));
+		return { ok: true, body: {} };
+	};
+
+	let invocation = 0;
+	originalProcessStreamingResponse = OpenaiApi.prototype.processStreamingResponse;
+	OpenaiApi.prototype.processStreamingResponse = async function (_body, progress) {
+		invocation += 1;
+		if (invocation === 1) {
+			progress.report(new LanguageModelThinkingPart("I should call the weather tool before replying."));
+			progress.report(new LanguageModelTextPart("I'll check that for you."));
+			progress.report(new LanguageModelToolCallPart("call_weather_1", "get_weather", { city: "Beijing" }));
+			return;
+		}
+		progress.report(new LanguageModelTextPart("It is sunny and 25°C."));
+	};
+
+	const firstProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, reasoningState);
+	await firstProvider.provideLanguageModelChatResponse(
+		reasoningOnModel,
+		firstTurnMessages,
+		{ tools: [weatherTool], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const secondProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, reasoningState);
+	await secondProvider.provideLanguageModelChatResponse(
+		reasoningOnModel,
+		secondTurnMessages,
+		{ tools: [weatherTool], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const replayRequest = requestBodies.at(-1);
+	const assistantMessage = replayRequest.messages.find((message) => message.role === "assistant");
+	const toolMessage = replayRequest.messages.find((message) => message.role === "tool");
+	if (!assistantMessage) {
+		throw new Error("Assistant replay message missing from replay request");
+	}
+	if (assistantMessage.content !== "I'll check that for you.") {
+		throw new Error(`Unexpected assistant replay content: ${assistantMessage.content ?? "<missing>"}`);
+	}
+	if (assistantMessage.reasoning_content !== "I should call the weather tool before replying.") {
+		throw new Error(`Unexpected replayed reasoning_content: ${assistantMessage.reasoning_content ?? "<missing>"}`);
+	}
+	if (!assistantMessage.tool_calls || assistantMessage.tool_calls.length !== 1) {
+		throw new Error("Replayed assistant tool_calls missing or malformed");
+	}
+	if (assistantMessage.tool_calls[0].id !== "call_weather_1") {
+		throw new Error("Replayed assistant tool call id mismatch");
+	}
+	if (assistantMessage.tool_calls[0].function.name !== "get_weather") {
+		throw new Error("Replayed assistant tool call name mismatch");
+	}
+	if (!toolMessage || toolMessage.tool_call_id !== "call_weather_1") {
+		throw new Error("Tool result replay missing or mismatched");
+	}
+	if (toolMessage.content !== '{"weather":"Sunny","temp":"25°C"}') {
+		throw new Error("Tool result content replay mismatch");
+	}
+
+	console.log("Tool reasoning replay validation passed.");
+	console.log(JSON.stringify({ assistantMessage, toolMessage }, null, 2));
+
+	const thirdProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, reasoningState);
+	await thirdProvider.provideLanguageModelChatResponse(
+		reasoningOffModel,
+		secondTurnMessages,
+		{ tools: [weatherTool], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const noReasoningRequest = requestBodies.at(-1);
+	const noReasoningAssistant = noReasoningRequest.messages.find((message) => message.role === "assistant");
+	if (!noReasoningAssistant) {
+		throw new Error("Assistant replay message missing for include_reasoning_in_request=false request");
+	}
+	if (noReasoningAssistant.reasoning_content !== undefined) {
+		throw new Error("reasoning_content leaked into include_reasoning_in_request=false tool replay request");
+	}
+	if (!noReasoningAssistant.tool_calls || noReasoningAssistant.tool_calls.length !== 1) {
+		throw new Error("Tool calls should remain present for include_reasoning_in_request=false tool replay request");
+	}
+
+	console.log("Tool variant-b isolation validation passed.");
+	console.log(JSON.stringify(noReasoningAssistant, null, 2));
+} finally {
+	Module._load = originalLoad;
+	globalThis.fetch = originalFetch;
+	if (originalProcessStreamingResponse) {
+		const outDir = path.resolve(__dirname, "../out");
+		const { OpenaiApi } = require(path.join(outDir, "openai/openaiApi.js"));
+		OpenaiApi.prototype.processStreamingResponse = originalProcessStreamingResponse;
+	}
+}

--- a/scripts/verify_tool_reasoning_replay.mjs
+++ b/scripts/verify_tool_reasoning_replay.mjs
@@ -179,7 +179,7 @@ try {
 		{ role: SYSTEM, content: [new LanguageModelTextPart("You are an assistant")] },
 		{ role: USER, content: [new LanguageModelTextPart("What's the weather like in Beijing?")] },
 	];
-
+	const firstTurnResponseParts = [];
 	const replayedAssistant = {
 		role: mockVscode.LanguageModelChatMessageRole.Assistant,
 		content: [
@@ -201,6 +201,23 @@ try {
 			],
 		},
 		{ role: USER, content: [new LanguageModelTextPart("Summarize the result.")] },
+	];
+	const secondTurnMessagesWithoutReasoning = [
+		firstTurnMessages[0],
+		firstTurnMessages[1],
+		{
+			role: mockVscode.LanguageModelChatMessageRole.Assistant,
+			content: [new LanguageModelToolCallPart("call_weather_2", "get_weather", { city: "Shanghai" })],
+		},
+		{
+			role: USER,
+			content: [
+				new LanguageModelToolResultPart("call_weather_2", [
+					new LanguageModelTextPart('{"weather":"Cloudy","temp":"20°C"}'),
+				]),
+			],
+		},
+		{ role: USER, content: [new LanguageModelTextPart("Summarize Shanghai too.")] },
 	];
 
 	const requestBodies = [];
@@ -227,9 +244,14 @@ try {
 		reasoningOnModel,
 		firstTurnMessages,
 		{ tools: [weatherTool], requestInitiator: "github.copilot-chat" },
-		{ report() {} },
+		{
+			report(part) {
+				firstTurnResponseParts.push(part);
+			},
+		},
 		token
 	);
+	replayedAssistant.content.push(...firstTurnResponseParts.filter((part) => part instanceof LanguageModelDataPart));
 
 	const secondProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, reasoningState);
 	await secondProvider.provideLanguageModelChatResponse(
@@ -270,6 +292,31 @@ try {
 
 	console.log("Tool reasoning replay validation passed.");
 	console.log(JSON.stringify({ assistantMessage, toolMessage }, null, 2));
+
+	const fallbackProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, reasoningState);
+	await fallbackProvider.provideLanguageModelChatResponse(
+		reasoningOnModel,
+		secondTurnMessagesWithoutReasoning,
+		{ tools: [weatherTool], requestInitiator: "github.copilot-chat" },
+		{ report() {} },
+		token
+	);
+
+	const missingReasoningFallbackRequest = requestBodies.at(-1);
+	const fallbackAssistant = missingReasoningFallbackRequest.messages.find(
+		(message) => message.role === "assistant" && message.tool_calls?.[0]?.id === "call_weather_2"
+	);
+	if (!fallbackAssistant) {
+		throw new Error("Assistant fallback replay message missing for empty reasoning case");
+	}
+	if (fallbackAssistant.reasoning_content !== "") {
+		throw new Error(
+			`Assistant fallback replay message should carry empty reasoning_content, got ${fallbackAssistant.reasoning_content ?? "<missing>"}`
+		);
+	}
+
+	console.log("Tool reasoning empty-field fallback validation passed.");
+	console.log(JSON.stringify(fallbackAssistant, null, 2));
 
 	const thirdProvider = new HuggingFaceChatModelProvider(secrets, statusBarItem, reasoningState);
 	await thirdProvider.provideLanguageModelChatResponse(

--- a/scripts/verify_tool_reasoning_shape.mjs
+++ b/scripts/verify_tool_reasoning_shape.mjs
@@ -1,0 +1,157 @@
+import Module, { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+
+class LanguageModelTextPart {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+class LanguageModelThinkingPart {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+class LanguageModelDataPart {
+	constructor(data, mimeType) {
+		this.data = data;
+		this.mimeType = mimeType;
+	}
+}
+
+class LanguageModelToolCallPart {
+	constructor(callId, name, input) {
+		this.callId = callId;
+		this.name = name;
+		this.input = input;
+	}
+}
+
+const mockVscode = {
+	LanguageModelTextPart,
+	LanguageModelThinkingPart,
+	LanguageModelDataPart,
+	LanguageModelToolCallPart,
+	LanguageModelChatMessageRole: {
+		User: 1,
+		Assistant: 2,
+		System: 3,
+	},
+	LanguageModelChatToolMode: {
+		Required: 1,
+	},
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+	if (request === "vscode") {
+		return mockVscode;
+	}
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+try {
+	const outDir = path.resolve(__dirname, "../out");
+	const { OpenaiApi } = require(path.join(outDir, "openai/openaiApi.js"));
+	const { convertToolsToOpenAI } = require(path.join(outDir, "utils.js"));
+
+	const USER = mockVscode.LanguageModelChatMessageRole.User;
+	const ASSISTANT = mockVscode.LanguageModelChatMessageRole.Assistant;
+	const SYSTEM = mockVscode.LanguageModelChatMessageRole.System;
+
+	const messages = [
+		{
+			role: SYSTEM,
+			content: [new LanguageModelTextPart("You are an assistant")],
+		},
+		{
+			role: USER,
+			content: [new LanguageModelTextPart("What's the weather like in Beijing?")],
+		},
+		{
+			role: ASSISTANT,
+			content: [
+				new LanguageModelTextPart("I'll check that for you."),
+				new LanguageModelThinkingPart("I should call the weather tool before replying."),
+				new LanguageModelToolCallPart("call_weather_1", "get_weather", { city: "Beijing" }),
+			],
+		},
+		{
+			role: USER,
+			content: [
+				{
+					callId: "call_weather_1",
+					content: [
+						new LanguageModelTextPart('{"weather":"Sunny","temp":"25°C"}'),
+					],
+				},
+			],
+		},
+	];
+
+	const toolConfig = convertToolsToOpenAI({
+		tools: [
+			{
+				name: "get_weather",
+				description: "Get weather information",
+				inputSchema: {
+					type: "object",
+					properties: {
+						city: { type: "string" },
+					},
+					required: ["city"],
+				},
+			},
+		],
+	});
+
+	const api = new OpenaiApi();
+	const converted = api.convertMessages(messages, { includeReasoningInRequest: true });
+
+	const assistantMessage = converted.find((message) => message.role === "assistant");
+	const toolMessage = converted.find((message) => message.role === "tool");
+
+	if (!assistantMessage) {
+		throw new Error("Assistant message missing from converted output");
+	}
+	if (assistantMessage.reasoning_content !== "I should call the weather tool before replying.") {
+		throw new Error(`Unexpected reasoning_content: ${assistantMessage.reasoning_content ?? "<missing>"}`);
+	}
+	if (!assistantMessage.tool_calls || assistantMessage.tool_calls.length !== 1) {
+		throw new Error("Assistant tool_calls were not serialized correctly");
+	}
+	if (assistantMessage.tool_calls[0].function.name !== "get_weather") {
+		throw new Error("Tool call function name mismatch");
+	}
+	if (!toolMessage || toolMessage.tool_call_id !== "call_weather_1") {
+		throw new Error("Tool result message missing or mismatched");
+	}
+	if (toolMessage.content !== '{"weather":"Sunny","temp":"25°C"}') {
+		throw new Error("Tool result content mismatch");
+	}
+	if (!toolConfig.tools || toolConfig.tools.length !== 1 || toolConfig.tools[0].function.name !== "get_weather") {
+		throw new Error("Top-level tools configuration mismatch");
+	}
+
+	console.log("Tool reasoning shape validation passed.");
+	console.log(
+		JSON.stringify(
+			{
+				requestShape: {
+					messages: converted,
+					...toolConfig,
+				},
+			},
+			null,
+			2
+		)
+	);
+} finally {
+	Module._load = originalLoad;
+}

--- a/scripts/verify_tool_reasoning_shape.mjs
+++ b/scripts/verify_tool_reasoning_shape.mjs
@@ -113,9 +113,19 @@ try {
 
 	const api = new OpenaiApi();
 	const converted = api.convertMessages(messages, { includeReasoningInRequest: true });
+	const convertedWithoutThinking = api.convertMessages(
+		[
+			{
+				role: ASSISTANT,
+				content: [new LanguageModelToolCallPart("call_weather_2", "get_weather", { city: "Shanghai" })],
+			},
+		],
+		{ includeReasoningInRequest: true }
+	);
 
 	const assistantMessage = converted.find((message) => message.role === "assistant");
 	const toolMessage = converted.find((message) => message.role === "tool");
+	const assistantWithoutThinking = convertedWithoutThinking.find((message) => message.role === "assistant");
 
 	if (!assistantMessage) {
 		throw new Error("Assistant message missing from converted output");
@@ -134,6 +144,14 @@ try {
 	}
 	if (toolMessage.content !== '{"weather":"Sunny","temp":"25°C"}') {
 		throw new Error("Tool result content mismatch");
+	}
+	if (!assistantWithoutThinking) {
+		throw new Error("Assistant tool-call-only message missing from converted output");
+	}
+	if (assistantWithoutThinking.reasoning_content !== "") {
+		throw new Error(
+			`Assistant tool-call-only message should serialize empty reasoning_content, got ${assistantWithoutThinking.reasoning_content ?? "<missing>"}`
+		);
 	}
 	if (!toolConfig.tools || toolConfig.tools.length !== 1 || toolConfig.tools[0].function.name !== "get_weather") {
 		throw new Error("Top-level tools configuration mismatch");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
 	TokenizerManager.initialize(context.extensionPath);
 
 	const tokenCountStatusBarItem: vscode.StatusBarItem = initStatusBar(context);
-	const provider = new HuggingFaceChatModelProvider(context.secrets, tokenCountStatusBarItem);
+	const provider = new HuggingFaceChatModelProvider(context.secrets, tokenCountStatusBarItem, context.workspaceState);
 	// Register the Hugging Face provider under the vendor id used in package.json
 	vscode.lm.registerLanguageModelChatProvider("oaicopilot", provider);
 

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -90,8 +90,8 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 					assistantMessage.content = joinedText;
 				}
 
-				if (modelConfig.includeReasoningInRequest) {
-					assistantMessage.reasoning_content = joinedThinking || "Next step.";
+				if (modelConfig.includeReasoningInRequest && joinedThinking) {
+					assistantMessage.reasoning_content = joinedThinking;
 				}
 
 				if (toolCalls.length > 0) {

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -90,7 +90,10 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 					assistantMessage.content = joinedText;
 				}
 
-				if (modelConfig.includeReasoningInRequest && joinedThinking) {
+				if (modelConfig.includeReasoningInRequest) {
+					// DeepSeek thinking mode expects assistant turns to carry the
+					// reasoning_content field on replay, even when the current turn
+					// does not expose a restorable reasoning payload locally.
 					assistantMessage.reasoning_content = joinedThinking;
 				}
 

--- a/src/provideToken.ts
+++ b/src/provideToken.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { LanguageModelChatRequestMessage, LanguageModelChatTool } from "vscode";
 import { tokenizerManager } from "./tokenizer/tokenizerManager";
 import { getImageDimensions } from "./tokenizer/imageUtils";
-import { createDataUrl } from "./utils";
+import { createDataUrl, isInternalMarkerMimeType } from "./utils";
 
 /*
  * Each message comes with 3 tokens per message due to special characters
@@ -31,6 +31,8 @@ export async function countMessageTokens(
 				// Estimate tokens for image or data parts based on type
 				if (part.mimeType.startsWith("image/")) {
 					totalTokens += calculateImageTokenCost(createDataUrl(part));
+				} else if (isInternalMarkerMimeType(part.mimeType)) {
+					/* ignore */
 				} else if (part.mimeType === "cache_control") {
 					/* ignore */
 				} else {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { gzipSync, gunzipSync } from "node:zlib";
 import {
 	CancellationToken,
 	LanguageModelChatInformation,
@@ -13,7 +14,15 @@ import type { HFModelItem } from "./types";
 
 import type { OllamaRequestBody } from "./ollama/ollamaTypes";
 
-import { parseModelId, createRetryConfig, executeWithRetry, normalizeUserModels } from "./utils";
+import {
+	parseModelId,
+	createRetryConfig,
+	executeWithRetry,
+	normalizeUserModels,
+	mapRole,
+	isToolResultPart,
+	collectToolResultText,
+} from "./utils";
 
 import { prepareLanguageModelChatInformation } from "./provideModel";
 import { countMessageTokens } from "./provideToken";
@@ -36,6 +45,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 
 	private readonly _geminiToolCallMetaByCallId = new Map<string, GeminiToolCallMeta>();
 	private readonly _openaiResponsesPreviousResponseIdUnsupportedBaseUrls = new Set<string>();
+	private readonly _openaiChatReasoningCache: PersistentOpenAIChatReasoningCache;
 
 	static readonly OPENAI_RESPONSES_STATEFUL_MARKER_MIME = "application/vnd.oaicopilot.stateful-marker";
 
@@ -45,8 +55,11 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	 */
 	constructor(
 		private readonly secrets: vscode.SecretStorage,
-		private readonly statusBarItem: vscode.StatusBarItem
-	) {}
+		private readonly statusBarItem: vscode.StatusBarItem,
+		reasoningState: vscode.Memento
+	) {
+		this._openaiChatReasoningCache = new PersistentOpenAIChatReasoningCache(reasoningState);
+	}
 
 	/**
 	 * Get the list of available language models contributed by this provider
@@ -123,8 +136,10 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 						(!parsedModelId.configId && !um.configId))
 			);
 
-			// If still no model found, try to find any model matching the base ID (most lenient match, for backward compatibility)
-			if (!um) {
+			// Only allow base-id fallback for legacy single-config models.
+			// When a configId is present, falling back can incorrectly pick another variant
+			// of the same base model and re-enable reasoning_content unexpectedly.
+			if (!um && !parsedModelId.configId) {
 				um = userModels.find((um) => um.id === parsedModelId.baseId);
 			}
 
@@ -425,7 +440,15 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 			} else {
 				// OpenAI compatible API mode (default)
 				const openaiApi = new OpenaiApi();
-				const openaiMessages = openaiApi.convertMessages(messages, modelConfig);
+				const restoredMessages = modelConfig.includeReasoningInRequest
+					? restoreOpenAIChatReasoningMessages(
+							parsedModelId.baseId,
+							options.requestInitiator,
+							messages,
+							this._openaiChatReasoningCache
+						)
+					: messages;
+				const openaiMessages = openaiApi.convertMessages(restoredMessages, modelConfig);
 
 				// requestBody
 				let requestBody: Record<string, unknown> = {
@@ -460,7 +483,38 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				if (!response.body) {
 					throw new Error("No response body from OAI Compatible API");
 				}
-				await openaiApi.processStreamingResponse(response.body, trackingProgress, token);
+
+				let aggregatedReasoning = "";
+				let aggregatedAssistantText = "";
+				const responseToolCalls: OpenAIChatToolCallSignature[] = [];
+				const openaiTrackingProgress: Progress<LanguageModelResponsePart2> = {
+					report: (part) => {
+						if (part instanceof vscode.LanguageModelThinkingPart) {
+							const text = Array.isArray(part.value) ? part.value.join("") : part.value;
+							if (text) {
+								aggregatedReasoning += text;
+							}
+						} else if (part instanceof vscode.LanguageModelTextPart) {
+							aggregatedAssistantText += part.value;
+						} else if (part instanceof vscode.LanguageModelToolCallPart) {
+							responseToolCalls.push(createOpenAIChatToolCallSignature(part));
+						}
+						trackingProgress.report(part);
+					},
+				};
+
+				await openaiApi.processStreamingResponse(response.body, openaiTrackingProgress, token);
+
+				if (modelConfig.includeReasoningInRequest && aggregatedReasoning.trim()) {
+					await this._openaiChatReasoningCache.remember(
+						parsedModelId.baseId,
+						options.requestInitiator,
+						messages,
+						aggregatedAssistantText,
+						responseToolCalls,
+						aggregatedReasoning
+					);
+				}
 			}
 		} catch (err) {
 			console.error("[OAI Compatible Model Provider] Chat request failed", {
@@ -524,6 +578,9 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 }
 
 type OpenAIResponsesStatefulMarkerLocation = { marker: string; index: number };
+type OpenAIChatToolCallSignature = { callId: string; name: string; inputJson: string };
+
+const OPENAI_CHAT_REASONING_CACHE_LIMIT = 256;
 
 function createOpenAIResponsesStatefulMarkerPart(modelId: string, marker: string): vscode.LanguageModelDataPart {
 	const payload = `${modelId}\\${marker}`;
@@ -580,3 +637,262 @@ function findLastOpenAIResponsesStatefulMarker(
 	}
 	return null;
 }
+
+function restoreOpenAIChatReasoningMessages(
+	modelId: string,
+	requestInitiator: string,
+	messages: readonly LanguageModelChatRequestMessage[],
+	reasoningCache: PersistentOpenAIChatReasoningCache
+): readonly LanguageModelChatRequestMessage[] {
+	return messages.map((message, messageIndex) => {
+		if (message.role !== vscode.LanguageModelChatMessageRole.Assistant) {
+			return message;
+		}
+
+		const content = [...(message.content ?? [])];
+		const hasThinking = content.some((part) => {
+			if (!(part instanceof vscode.LanguageModelThinkingPart)) {
+				return false;
+			}
+			const value = Array.isArray(part.value) ? part.value.join("") : part.value;
+			return !!value.trim();
+		});
+		if (hasThinking) {
+			return message;
+		}
+
+		const { assistantText, toolCalls } = extractAssistantMessageSignature(content);
+		const restoredReasoning = reasoningCache.recall(
+			modelId,
+			requestInitiator,
+			messages.slice(0, messageIndex),
+			assistantText,
+			toolCalls
+		);
+		if (!restoredReasoning) {
+			return message;
+		}
+
+		return {
+			...message,
+			content: [...content, new vscode.LanguageModelThinkingPart(restoredReasoning)],
+		} as LanguageModelChatRequestMessage;
+	});
+}
+
+function createOpenAIChatToolCallSignature(part: vscode.LanguageModelToolCallPart): OpenAIChatToolCallSignature {
+	return {
+		callId: part.callId || "",
+		name: part.name,
+		inputJson: stableStringify(part.input ?? {}),
+	};
+}
+
+function extractAssistantMessageSignature(content: readonly unknown[]): {
+	assistantText: string;
+	toolCalls: OpenAIChatToolCallSignature[];
+} {
+	let assistantText = "";
+	const toolCalls: OpenAIChatToolCallSignature[] = [];
+	for (const part of content) {
+		if (part instanceof vscode.LanguageModelTextPart) {
+			assistantText += part.value;
+		} else if (part instanceof vscode.LanguageModelToolCallPart) {
+			toolCalls.push(createOpenAIChatToolCallSignature(part));
+		}
+	}
+	return { assistantText, toolCalls };
+}
+
+function extractOpenAIChatReasoningAnchor(
+	prefixMessages: readonly LanguageModelChatRequestMessage[]
+): Record<string, unknown> | null {
+	for (let index = prefixMessages.length - 1; index >= 0; index--) {
+		const message = prefixMessages[index];
+		if (message.role === vscode.LanguageModelChatMessageRole.Assistant) {
+			continue;
+		}
+		const normalized = normalizeMessageForReasoningCache(message);
+		const normalizedContent = normalized.content;
+		if (Array.isArray(normalizedContent) && normalizedContent.length > 0) {
+			return normalized;
+		}
+	}
+	return null;
+}
+
+function buildOpenAIChatReasoningTurnCacheKey(
+	modelId: string,
+	requestInitiator: string,
+	prefixMessages: readonly LanguageModelChatRequestMessage[],
+	assistantText: string,
+	toolCalls: readonly OpenAIChatToolCallSignature[]
+): string {
+	return stableStringify({
+		modelId,
+		requestInitiator,
+		recentAnchor: extractOpenAIChatReasoningAnchor(prefixMessages),
+		assistantText,
+		toolCalls,
+	});
+}
+
+function buildOpenAIChatReasoningFallbackCacheKey(
+	modelId: string,
+	requestInitiator: string,
+	assistantText: string,
+	toolCalls: readonly OpenAIChatToolCallSignature[]
+): string {
+	return stableStringify({
+		modelId,
+		requestInitiator,
+		assistantText,
+		toolCalls,
+	});
+}
+
+function normalizeMessageForReasoningCache(message: LanguageModelChatRequestMessage): Record<string, unknown> {
+	const normalizedContent: Array<Record<string, unknown>> = [];
+	for (const part of message.content ?? []) {
+		if (part instanceof vscode.LanguageModelTextPart) {
+			if (part.value) {
+				normalizedContent.push({ type: "text", value: part.value });
+			}
+			continue;
+		}
+		if (part instanceof vscode.LanguageModelToolCallPart) {
+			normalizedContent.push({ type: "tool_call", ...createOpenAIChatToolCallSignature(part) });
+			continue;
+		}
+		if (isToolResultPart(part)) {
+			normalizedContent.push({
+				type: "tool_result",
+				callId: part.callId,
+				content: collectToolResultText(part),
+			});
+			continue;
+		}
+		if (part instanceof vscode.LanguageModelDataPart) {
+			normalizedContent.push({ type: "data", mimeType: part.mimeType, byteLength: part.data.byteLength });
+		}
+	}
+	return {
+		role: mapRole(message),
+		content: normalizedContent,
+	};
+}
+
+function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+	}
+	if (value && typeof value === "object") {
+		const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) => left.localeCompare(right));
+		return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`).join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+type PersistentReasoningEntry = {
+	key: string;
+	payload: string;
+	updatedAt: number;
+};
+
+class PersistentOpenAIChatReasoningCache {
+	private static readonly STORAGE_KEY = "oaicopilot.openaiChatReasoningCache.v2";
+	private readonly entries = new Map<string, PersistentReasoningEntry>();
+
+	constructor(private readonly state: vscode.Memento) {
+		const stored = state.get<PersistentReasoningEntry[]>(PersistentOpenAIChatReasoningCache.STORAGE_KEY, []);
+		for (const entry of stored) {
+			if (entry?.key && entry?.payload) {
+				this.entries.set(entry.key, entry);
+			}
+		}
+	}
+
+	recall(
+		modelId: string,
+		requestInitiator: string,
+		prefixMessages: readonly LanguageModelChatRequestMessage[],
+		assistantText: string,
+		toolCalls: readonly OpenAIChatToolCallSignature[]
+	): string {
+		const key = buildOpenAIChatReasoningTurnCacheKey(
+			modelId,
+			requestInitiator,
+			prefixMessages,
+			assistantText,
+			toolCalls
+		);
+		const fallbackKey = buildOpenAIChatReasoningFallbackCacheKey(
+			modelId,
+			requestInitiator,
+			assistantText,
+			toolCalls
+		);
+		const matchedKey = this.entries.has(key) ? key : this.entries.has(fallbackKey) ? fallbackKey : "";
+		const entry = matchedKey ? this.entries.get(matchedKey) : undefined;
+		if (!entry) {
+			return "";
+		}
+		try {
+			return gunzipSync(Buffer.from(entry.payload, "base64url")).toString("utf8");
+		} catch {
+			this.entries.delete(matchedKey);
+			void this.flush();
+			return "";
+		}
+	}
+
+	async remember(
+		modelId: string,
+		requestInitiator: string,
+		prefixMessages: readonly LanguageModelChatRequestMessage[],
+		assistantText: string,
+		toolCalls: readonly OpenAIChatToolCallSignature[],
+		reasoning: string
+	): Promise<void> {
+		const key = buildOpenAIChatReasoningTurnCacheKey(
+			modelId,
+			requestInitiator,
+			prefixMessages,
+			assistantText,
+			toolCalls
+		);
+		const fallbackKey = buildOpenAIChatReasoningFallbackCacheKey(
+			modelId,
+			requestInitiator,
+			assistantText,
+			toolCalls
+		);
+		const payload = gzipSync(reasoning).toString("base64url");
+		const upsert = (entryKey: string) => {
+			if (this.entries.has(entryKey)) {
+				this.entries.delete(entryKey);
+			}
+			this.entries.set(entryKey, { key: entryKey, payload, updatedAt: Date.now() });
+		};
+		upsert(key);
+		if (fallbackKey !== key) {
+			upsert(fallbackKey);
+		}
+		while (this.entries.size > OPENAI_CHAT_REASONING_CACHE_LIMIT) {
+			const oldestKey = this.entries.keys().next().value;
+			if (!oldestKey) {
+				break;
+			}
+			this.entries.delete(oldestKey);
+		}
+		await this.flush();
+	}
+
+	private async flush(): Promise<void> {
+		await this.state.update(
+			PersistentOpenAIChatReasoningCache.STORAGE_KEY,
+			Array.from(this.entries.values())
+		);
+	}
+}
+

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,8 @@
 import * as vscode from "vscode";
+import { randomUUID } from "node:crypto";
+import { appendFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { gzipSync, gunzipSync } from "node:zlib";
 import {
 	CancellationToken,
@@ -22,6 +26,7 @@ import {
 	mapRole,
 	isToolResultPart,
 	collectToolResultText,
+	isInternalMarkerMimeType,
 } from "./utils";
 
 import { prepareLanguageModelChatInformation } from "./provideModel";
@@ -36,6 +41,102 @@ import { GeminiApi, buildGeminiGenerateContentUrl, type GeminiToolCallMeta } fro
 import type { GeminiGenerateContentRequest } from "./gemini/geminiTypes";
 import { CommonApi } from "./commonApi";
 
+const DEBUG_LOG_PATH = path.join(tmpdir(), "oaicopilot-deepseek-debug.log");
+const DEBUG_LOG_ENABLED = process.env.OAICOPILOT_DEBUG_LOG === "1";
+
+function safeDebugStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch (error) {
+		return JSON.stringify({
+			stringifyError: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+function summarizeChatRequestMessages(messages: readonly LanguageModelChatRequestMessage[]): Array<Record<string, unknown>> {
+	return messages.map((message, index) => {
+		const summary: Record<string, unknown> = {
+			index,
+			role: mapRole(message),
+			partTypes: [],
+			text: "",
+			thinking: "",
+			toolCalls: [],
+			toolResults: [],
+			markers: [],
+		};
+		for (const part of message.content ?? []) {
+			if (part instanceof vscode.LanguageModelTextPart) {
+				summary.partTypes = [...(summary.partTypes as unknown[]), "text"];
+				summary.text = `${summary.text ?? ""}${part.value}`;
+			} else if (part instanceof vscode.LanguageModelThinkingPart) {
+				const value = Array.isArray(part.value) ? part.value.join("") : part.value;
+				summary.partTypes = [...(summary.partTypes as unknown[]), "thinking"];
+				summary.thinking = `${summary.thinking ?? ""}${value}`;
+			} else if (part instanceof vscode.LanguageModelToolCallPart) {
+				summary.partTypes = [...(summary.partTypes as unknown[]), "tool_call"];
+				(summary.toolCalls as unknown[]).push({
+					callId: part.callId,
+					name: part.name,
+					input: part.input ?? {},
+				});
+			} else if (isToolResultPart(part)) {
+				summary.partTypes = [...(summary.partTypes as unknown[]), "tool_result"];
+				(summary.toolResults as unknown[]).push({
+					callId: part.callId,
+					content: collectToolResultText(part),
+				});
+			} else if (part instanceof vscode.LanguageModelDataPart) {
+				summary.partTypes = [...(summary.partTypes as unknown[]), `data:${part.mimeType}`];
+				if (isInternalMarkerMimeType(part.mimeType)) {
+					(summary.markers as unknown[]).push(part.mimeType);
+				}
+			}
+		}
+		return summary;
+	});
+}
+
+function summarizeOpenAIChatMessages(messages: readonly unknown[]): Array<Record<string, unknown>> {
+	return messages.map((message, index) => {
+		const normalized = (message ?? {}) as {
+			role?: unknown;
+			content?: unknown;
+			reasoning_content?: unknown;
+			tool_calls?: unknown;
+			tool_call_id?: unknown;
+		};
+		return {
+		index,
+		role: normalized.role,
+		content: normalized.content,
+		reasoning_content: normalized.reasoning_content,
+		tool_calls: normalized.tool_calls,
+		tool_call_id: normalized.tool_call_id,
+		};
+	});
+}
+
+async function appendDeepSeekDebugLog(event: string, payload: Record<string, unknown>): Promise<void> {
+	if (!DEBUG_LOG_ENABLED) {
+		return;
+	}
+	const line = [
+		`=== ${new Date().toISOString()} ${event} ===`,
+		safeDebugStringify(payload),
+		"",
+	].join("\n");
+	try {
+		await appendFile(DEBUG_LOG_PATH, line, "utf8");
+	} catch (error) {
+		console.error("[OAI Compatible Model Provider] Failed to write debug log", {
+			path: DEBUG_LOG_PATH,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
 /**
  * VS Code Chat provider backed by Hugging Face Inference Providers.
  */
@@ -48,6 +149,8 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 	private readonly _openaiChatReasoningCache: PersistentOpenAIChatReasoningCache;
 
 	static readonly OPENAI_RESPONSES_STATEFUL_MARKER_MIME = "application/vnd.oaicopilot.stateful-marker";
+	static readonly OPENAI_CHAT_STATE_MARKER_MIME = "application/vnd.oaicopilot.openai-chat-state";
+	static readonly OPENAI_CHAT_REASONING_MARKER_MIME = "application/vnd.oaicopilot.openai-chat-reasoning";
 
 	/**
 	 * Create a provider using the given secret storage for the API key.
@@ -208,6 +311,17 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 
 				// send Ollama chat request with retry
 				const url = `${BASE_URL.replace(/\/+$/, "")}/api/chat`;
+				void appendDeepSeekDebugLog("request-preflight", {
+					modelId: model.id,
+					baseModelId: parsedModelId.baseId,
+					requestInitiator: options.requestInitiator,
+					apiMode,
+					baseUrl: BASE_URL,
+					url,
+					originalMessages: summarizeChatRequestMessages(messages),
+					requestBody: ollamaRequestBody,
+					debugLogPath: DEBUG_LOG_PATH,
+				});
 				const response = await executeWithRetry(async () => {
 					const res = await fetch(url, {
 						method: "POST",
@@ -218,6 +332,20 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					if (!res.ok) {
 						const errorText = await res.text();
 						console.error("[Ollama Provider] Ollama API error response", errorText);
+						void appendDeepSeekDebugLog("request-error", {
+							modelId: model.id,
+							baseModelId: parsedModelId.baseId,
+							requestInitiator: options.requestInitiator,
+							apiMode,
+							baseUrl: BASE_URL,
+							url,
+							status: res.status,
+							statusText: res.statusText,
+							errorText,
+							originalMessages: summarizeChatRequestMessages(messages),
+							requestBody: ollamaRequestBody,
+							debugLogPath: DEBUG_LOG_PATH,
+						});
 						throw new Error(
 							`Ollama API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
 						);
@@ -251,6 +379,17 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				const url = normalizedBaseUrl.endsWith("/v1")
 					? `${normalizedBaseUrl}/messages`
 					: `${normalizedBaseUrl}/v1/messages`;
+				void appendDeepSeekDebugLog("request-preflight", {
+					modelId: model.id,
+					baseModelId: parsedModelId.baseId,
+					requestInitiator: options.requestInitiator,
+					apiMode,
+					baseUrl: BASE_URL,
+					url,
+					originalMessages: summarizeChatRequestMessages(messages),
+					requestBody,
+					debugLogPath: DEBUG_LOG_PATH,
+				});
 				const response = await executeWithRetry(async () => {
 					const res = await fetch(url, {
 						method: "POST",
@@ -261,6 +400,20 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					if (!res.ok) {
 						const errorText = await res.text();
 						console.error("[Anthropic Provider] Anthropic API error response", errorText);
+						void appendDeepSeekDebugLog("request-error", {
+							modelId: model.id,
+							baseModelId: parsedModelId.baseId,
+							requestInitiator: options.requestInitiator,
+							apiMode,
+							baseUrl: BASE_URL,
+							url,
+							status: res.status,
+							statusText: res.statusText,
+							errorText,
+							originalMessages: summarizeChatRequestMessages(messages),
+							requestBody,
+							debugLogPath: DEBUG_LOG_PATH,
+						});
 						throw new Error(
 							`Anthropic API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
 						);
@@ -321,8 +474,19 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					addedPreviousResponseId = true;
 				}
 
-				const sendRequest = async (body: Record<string, unknown>) =>
-					await executeWithRetry(async () => {
+				const sendRequest = async (body: Record<string, unknown>) => {
+					void appendDeepSeekDebugLog("request-preflight", {
+						modelId: model.id,
+						baseModelId: parsedModelId.baseId,
+						requestInitiator: options.requestInitiator,
+						apiMode,
+						baseUrl: BASE_URL,
+						url,
+						originalMessages: summarizeChatRequestMessages(messages),
+						requestBody: body,
+						debugLogPath: DEBUG_LOG_PATH,
+					});
+					return await executeWithRetry(async () => {
 						const res = await fetch(url, {
 							method: "POST",
 							headers: requestHeaders,
@@ -331,6 +495,20 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 
 						if (!res.ok) {
 							const errorText = await res.text();
+							void appendDeepSeekDebugLog("request-error", {
+								modelId: model.id,
+								baseModelId: parsedModelId.baseId,
+								requestInitiator: options.requestInitiator,
+								apiMode,
+								baseUrl: BASE_URL,
+								url,
+								status: res.status,
+								statusText: res.statusText,
+								errorText,
+								originalMessages: summarizeChatRequestMessages(messages),
+								requestBody: body,
+								debugLogPath: DEBUG_LOG_PATH,
+							});
 							const error = new Error(
 								`Responses API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
 							);
@@ -341,6 +519,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 
 						return res;
 					}, retryConfig);
+				};
 
 				let response: Response;
 				try {
@@ -415,6 +594,17 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					throw new Error("Invalid Gemini base URL configuration.");
 				}
 
+				void appendDeepSeekDebugLog("request-preflight", {
+					modelId: model.id,
+					baseModelId: parsedModelId.baseId,
+					requestInitiator: options.requestInitiator,
+					apiMode,
+					baseUrl: BASE_URL,
+					url,
+					originalMessages: summarizeChatRequestMessages(messages),
+					requestBody,
+					debugLogPath: DEBUG_LOG_PATH,
+				});
 				const response = await executeWithRetry(async () => {
 					const res = await fetch(url, {
 						method: "POST",
@@ -425,6 +615,20 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					if (!res.ok) {
 						const errorText = await res.text();
 						console.error("[Gemini Provider] Gemini API error response", errorText);
+						void appendDeepSeekDebugLog("request-error", {
+							modelId: model.id,
+							baseModelId: parsedModelId.baseId,
+							requestInitiator: options.requestInitiator,
+							apiMode,
+							baseUrl: BASE_URL,
+							url,
+							status: res.status,
+							statusText: res.statusText,
+							errorText,
+							originalMessages: summarizeChatRequestMessages(messages),
+							requestBody,
+							debugLogPath: DEBUG_LOG_PATH,
+						});
 						throw new Error(
 							`Gemini API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
 						);
@@ -437,45 +641,86 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 					throw new Error("No response body from Gemini API");
 				}
 				await geminiApi.processStreamingResponse(response.body, trackingProgress, token);
-			} else {
-				// OpenAI compatible API mode (default)
-				const openaiApi = new OpenaiApi();
+				} else {
+					// OpenAI compatible API mode (default)
+					const openaiApi = new OpenaiApi();
+					const reasoningModelScopeId = parsedModelId.configId ? model.id : parsedModelId.baseId;
+					const openAIChatConversationState = modelConfig.includeReasoningInRequest
+					? getOrCreateOpenAIChatConversationState(reasoningModelScopeId, options.requestInitiator, messages)
+					: null;
 				const restoredMessages = modelConfig.includeReasoningInRequest
 					? restoreOpenAIChatReasoningMessages(
-							parsedModelId.baseId,
+							reasoningModelScopeId,
 							options.requestInitiator,
 							messages,
 							this._openaiChatReasoningCache
 						)
-					: messages;
-				const openaiMessages = openaiApi.convertMessages(restoredMessages, modelConfig);
+						: messages;
+					const openaiMessages = openaiApi.convertMessages(restoredMessages, modelConfig);
 
-				// requestBody
-				let requestBody: Record<string, unknown> = {
+					// requestBody
+					let requestBody: Record<string, unknown> = {
 					model: parsedModelId.baseId,
 					messages: openaiMessages,
 					stream: true,
-					stream_options: { include_usage: true },
-				};
-				requestBody = openaiApi.prepareRequestBody(requestBody, um, options);
-				// console.debug("[OAI Compatible Model Provider] RequestBody:", JSON.stringify(requestBody));
+						stream_options: { include_usage: true },
+					};
+					requestBody = openaiApi.prepareRequestBody(requestBody, um, options);
+					{
+						void appendDeepSeekDebugLog("request-preflight", {
+							modelId: model.id,
+							baseModelId: parsedModelId.baseId,
+							requestInitiator: options.requestInitiator,
+							apiMode,
+							baseUrl: BASE_URL,
+							includeReasoningInRequest: modelConfig.includeReasoningInRequest,
+							reasoningModelScopeId,
+							conversationId: openAIChatConversationState?.conversationId ?? null,
+							originalMessages: summarizeChatRequestMessages(messages),
+							restoredMessages: summarizeChatRequestMessages(restoredMessages),
+							openaiMessages: summarizeOpenAIChatMessages(openaiMessages),
+							requestBody,
+							debugLogPath: DEBUG_LOG_PATH,
+						});
+					}
 
-				// send chat request with retry
-				const url = `${BASE_URL.replace(/\/+$/, "")}/chat/completions`;
-				const response = await executeWithRetry(async () => {
-					const res = await fetch(url, {
+					// send chat request with retry
+					const url = `${BASE_URL.replace(/\/+$/, "")}/chat/completions`;
+					const response = await executeWithRetry(async () => {
+						const res = await fetch(url, {
 						method: "POST",
 						headers: requestHeaders,
 						body: JSON.stringify(requestBody),
 					});
 
-					if (!res.ok) {
-						const errorText = await res.text();
-						console.error("[OAI Compatible Model Provider] OAI Compatible API error response", errorText);
-						throw new Error(
-							`OAI Compatible API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
-						);
-					}
+						if (!res.ok) {
+							const errorText = await res.text();
+							console.error("[OAI Compatible Model Provider] OAI Compatible API error response", errorText);
+							{
+								void appendDeepSeekDebugLog("request-error", {
+									modelId: model.id,
+									baseModelId: parsedModelId.baseId,
+									requestInitiator: options.requestInitiator,
+									apiMode,
+									baseUrl: BASE_URL,
+									url,
+									status: res.status,
+									statusText: res.statusText,
+									errorText,
+									includeReasoningInRequest: modelConfig.includeReasoningInRequest,
+									reasoningModelScopeId,
+									conversationId: openAIChatConversationState?.conversationId ?? null,
+									originalMessages: summarizeChatRequestMessages(messages),
+									restoredMessages: summarizeChatRequestMessages(restoredMessages),
+									openaiMessages: summarizeOpenAIChatMessages(openaiMessages),
+									requestBody,
+									debugLogPath: DEBUG_LOG_PATH,
+								});
+							}
+							throw new Error(
+								`OAI Compatible API error: [${res.status}] ${res.statusText}${errorText ? `\n${errorText}` : ""}\nURL: ${url}`
+							);
+						}
 
 					return res;
 				}, retryConfig);
@@ -505,15 +750,40 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 
 				await openaiApi.processStreamingResponse(response.body, openaiTrackingProgress, token);
 
-				if (modelConfig.includeReasoningInRequest && aggregatedReasoning.trim()) {
-					await this._openaiChatReasoningCache.remember(
-						parsedModelId.baseId,
-						options.requestInitiator,
-						messages,
-						aggregatedAssistantText,
-						responseToolCalls,
-						aggregatedReasoning
+				const hasVisibleOrReasoningResponse =
+					!!aggregatedAssistantText || responseToolCalls.length > 0 || !!aggregatedReasoning.trim();
+				if (modelConfig.includeReasoningInRequest && openAIChatConversationState && hasVisibleOrReasoningResponse) {
+					const messageId = randomUUID();
+					trackingProgress.report(
+						createOpenAIChatStateMarkerPart(
+							reasoningModelScopeId,
+							options.requestInitiator,
+							openAIChatConversationState.conversationId,
+							messageId
+						)
 					);
+
+					if (aggregatedReasoning.trim()) {
+						trackingProgress.report(
+							createOpenAIChatReasoningMarkerPart(
+								reasoningModelScopeId,
+								options.requestInitiator,
+								openAIChatConversationState.conversationId,
+								messageId,
+								aggregatedReasoning
+							)
+						);
+						await this._openaiChatReasoningCache.remember(
+							reasoningModelScopeId,
+							options.requestInitiator,
+							openAIChatConversationState.conversationId,
+							messageId,
+							aggregatedReasoning,
+							messages,
+							aggregatedAssistantText,
+							responseToolCalls
+						);
+					}
 				}
 			}
 		} catch (err) {
@@ -580,7 +850,21 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 type OpenAIResponsesStatefulMarkerLocation = { marker: string; index: number };
 type OpenAIChatToolCallSignature = { callId: string; name: string; inputJson: string };
 
-const OPENAI_CHAT_REASONING_CACHE_LIMIT = 256;
+type OpenAIChatConversationState = { conversationId: string };
+type OpenAIChatStateMarkerPayload = {
+	version: 1;
+	modelId: string;
+	requestInitiator?: string;
+	conversationId: string;
+	messageId: string;
+};
+type OpenAIChatReasoningMarkerPayload = OpenAIChatStateMarkerPayload & {
+	reasoning: string;
+};
+
+const OPENAI_CHAT_REASONING_CACHE_TOTAL_LIMIT = 8192;
+const OPENAI_CHAT_REASONING_CACHE_SESSION_LIMIT = 2048;
+const OPENAI_CHAT_REASONING_CACHE_TTL_MS = 1000 * 60 * 60 * 24 * 30;
 
 function createOpenAIResponsesStatefulMarkerPart(modelId: string, marker: string): vscode.LanguageModelDataPart {
 	const payload = `${modelId}\\${marker}`;
@@ -618,6 +902,165 @@ function parseOpenAIResponsesStatefulMarkerPart(part: unknown): { modelId: strin
 	} catch {
 		return null;
 	}
+}
+
+function createCompressedMarkerPart(mimeType: string, payload: Record<string, unknown>): vscode.LanguageModelDataPart {
+	return new vscode.LanguageModelDataPart(gzipSync(JSON.stringify(payload)), mimeType);
+}
+
+function parseCompressedMarkerPart<T extends Record<string, unknown>>(part: unknown, mimeType: string): T | null {
+	const maybe = part as { mimeType?: unknown; data?: unknown };
+	if (!maybe || typeof maybe !== "object") {
+		return null;
+	}
+	if (maybe.mimeType !== mimeType) {
+		return null;
+	}
+	if (!(maybe.data instanceof Uint8Array)) {
+		return null;
+	}
+
+	try {
+		const decoded = gunzipSync(Buffer.from(maybe.data)).toString("utf8");
+		const parsed = JSON.parse(decoded);
+		return parsed && typeof parsed === "object" ? (parsed as T) : null;
+	} catch {
+		return null;
+	}
+}
+
+function createOpenAIChatStateMarkerPart(
+	modelId: string,
+	requestInitiator: string,
+	conversationId: string,
+	messageId: string
+): vscode.LanguageModelDataPart {
+	return createCompressedMarkerPart(HuggingFaceChatModelProvider.OPENAI_CHAT_STATE_MARKER_MIME, {
+		version: 1,
+		modelId,
+		requestInitiator,
+		conversationId,
+		messageId,
+	});
+}
+
+function parseOpenAIChatStateMarkerPart(part: unknown): OpenAIChatStateMarkerPayload | null {
+	const parsed = parseCompressedMarkerPart<OpenAIChatStateMarkerPayload>(
+		part,
+		HuggingFaceChatModelProvider.OPENAI_CHAT_STATE_MARKER_MIME
+	);
+	if (!parsed || parsed.version !== 1) {
+		return null;
+	}
+	if (!parsed.modelId || !parsed.conversationId || !parsed.messageId) {
+		return null;
+	}
+	return parsed;
+}
+
+function createOpenAIChatReasoningMarkerPart(
+	modelId: string,
+	requestInitiator: string,
+	conversationId: string,
+	messageId: string,
+	reasoning: string
+): vscode.LanguageModelDataPart {
+	return createCompressedMarkerPart(HuggingFaceChatModelProvider.OPENAI_CHAT_REASONING_MARKER_MIME, {
+		version: 1,
+		modelId,
+		requestInitiator,
+		conversationId,
+		messageId,
+		reasoning,
+	});
+}
+
+function markerMatchesRequestInitiator(
+	marker: { requestInitiator?: string },
+	requestInitiator: string,
+	allowLegacyMarker: boolean
+): boolean {
+	if (!marker.requestInitiator) {
+		return allowLegacyMarker;
+	}
+	return marker.requestInitiator === requestInitiator;
+}
+
+function parseOpenAIChatReasoningMarkerPart(part: unknown): OpenAIChatReasoningMarkerPayload | null {
+	const parsed = parseCompressedMarkerPart<OpenAIChatReasoningMarkerPayload>(
+		part,
+		HuggingFaceChatModelProvider.OPENAI_CHAT_REASONING_MARKER_MIME
+	);
+	if (!parsed || parsed.version !== 1) {
+		return null;
+	}
+	if (!parsed.modelId || !parsed.conversationId || !parsed.messageId || typeof parsed.reasoning !== "string") {
+		return null;
+	}
+	return parsed;
+}
+
+function extractOpenAIChatMessageState(
+	modelId: string,
+	content: readonly unknown[],
+	requestInitiator: string,
+	allowLegacyMarker = true
+): OpenAIChatStateMarkerPayload | null {
+	for (const part of content) {
+		const stateMarker = parseOpenAIChatStateMarkerPart(part);
+		if (
+			stateMarker &&
+			stateMarker.modelId === modelId &&
+			markerMatchesRequestInitiator(stateMarker, requestInitiator, allowLegacyMarker)
+		) {
+			return stateMarker;
+		}
+		const reasoningMarker = parseOpenAIChatReasoningMarkerPart(part);
+		if (
+			reasoningMarker &&
+			reasoningMarker.modelId === modelId &&
+			markerMatchesRequestInitiator(reasoningMarker, requestInitiator, allowLegacyMarker)
+		) {
+			return reasoningMarker;
+		}
+	}
+	return null;
+}
+
+function extractOpenAIChatMessageReasoning(
+	modelId: string,
+	content: readonly unknown[],
+	requestInitiator: string
+): OpenAIChatReasoningMarkerPayload | null {
+	for (const part of content) {
+		const marker = parseOpenAIChatReasoningMarkerPart(part);
+		if (
+			marker &&
+			marker.modelId === modelId &&
+			markerMatchesRequestInitiator(marker, requestInitiator, false)
+		) {
+			return marker;
+		}
+	}
+	return null;
+}
+
+function getOrCreateOpenAIChatConversationState(
+	modelId: string,
+	requestInitiator: string,
+	messages: readonly LanguageModelChatRequestMessage[]
+): OpenAIChatConversationState {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message.role !== vscode.LanguageModelChatMessageRole.Assistant) {
+			continue;
+		}
+		const state = extractOpenAIChatMessageState(modelId, message.content ?? [], requestInitiator, true);
+		if (state) {
+			return { conversationId: state.conversationId };
+		}
+	}
+	return { conversationId: randomUUID() };
 }
 
 function findLastOpenAIResponsesStatefulMarker(
@@ -661,14 +1104,30 @@ function restoreOpenAIChatReasoningMessages(
 			return message;
 		}
 
-		const { assistantText, toolCalls } = extractAssistantMessageSignature(content);
-		const restoredReasoning = reasoningCache.recall(
-			modelId,
-			requestInitiator,
-			messages.slice(0, messageIndex),
-			assistantText,
-			toolCalls
-		);
+		const markerReasoning = extractOpenAIChatMessageReasoning(modelId, content, requestInitiator)?.reasoning ?? "";
+		const stateMarker = extractOpenAIChatMessageState(modelId, content, requestInitiator, true);
+		let restoredReasoning = markerReasoning;
+		if (!restoredReasoning && stateMarker) {
+			restoredReasoning = reasoningCache.recall(
+				modelId,
+				requestInitiator,
+				stateMarker.conversationId,
+				stateMarker.messageId
+			);
+		}
+		if (!restoredReasoning) {
+			const { assistantText, toolCalls } = extractAssistantMessageSignature(content);
+			// VS Code can omit internal marker/data parts when replaying assistant turns back
+			// into the provider. Fall back to the persisted signature-based lookup so
+			// preserved thinking still works for the same request initiator.
+			restoredReasoning = reasoningCache.recallLegacy(
+				modelId,
+				requestInitiator,
+				messages.slice(0, messageIndex),
+				assistantText,
+				toolCalls
+			);
+		}
 		if (!restoredReasoning) {
 			return message;
 		}
@@ -773,6 +1232,9 @@ function normalizeMessageForReasoningCache(message: LanguageModelChatRequestMess
 			continue;
 		}
 		if (part instanceof vscode.LanguageModelDataPart) {
+			if (isInternalMarkerMimeType(part.mimeType)) {
+				continue;
+			}
 			normalizedContent.push({ type: "data", mimeType: part.mimeType, byteLength: part.data.byteLength });
 		}
 	}
@@ -799,20 +1261,107 @@ type PersistentReasoningEntry = {
 	updatedAt: number;
 };
 
+type PersistentReasoningMessageRecord = {
+	messageId: string;
+	payload: string;
+	updatedAt: number;
+};
+
+type PersistentReasoningSessionRecord = {
+	sessionKey: string;
+	modelId: string;
+	requestInitiator: string;
+	conversationId: string;
+	updatedAt: number;
+	messages: PersistentReasoningMessageRecord[];
+};
+
+type PersistentReasoningSessionBucket = Omit<PersistentReasoningSessionRecord, "messages"> & {
+	messages: Map<string, PersistentReasoningMessageRecord>;
+};
+
+type PersistentReasoningIndexRecord = {
+	key: string;
+	sessionKey: string;
+	messageId: string;
+	updatedAt: number;
+};
+
 class PersistentOpenAIChatReasoningCache {
-	private static readonly STORAGE_KEY = "oaicopilot.openaiChatReasoningCache.v2";
-	private readonly entries = new Map<string, PersistentReasoningEntry>();
+	private static readonly LEGACY_STORAGE_KEY = "oaicopilot.openaiChatReasoningCache.v2";
+	private static readonly STORAGE_KEY = "oaicopilot.openaiChatReasoningCache.v3";
+	private static readonly INDEX_STORAGE_KEY = "oaicopilot.openaiChatReasoningCache.v3.indices";
+	private readonly sessions = new Map<string, PersistentReasoningSessionBucket>();
+	private readonly legacyEntries = new Map<string, PersistentReasoningEntry>();
+	private readonly indices = new Map<string, PersistentReasoningIndexRecord>();
 
 	constructor(private readonly state: vscode.Memento) {
-		const stored = state.get<PersistentReasoningEntry[]>(PersistentOpenAIChatReasoningCache.STORAGE_KEY, []);
-		for (const entry of stored) {
+		const now = Date.now();
+		const stored = state.get<PersistentReasoningSessionRecord[]>(PersistentOpenAIChatReasoningCache.STORAGE_KEY, []);
+		for (const session of stored) {
+			if (!session?.sessionKey || !session.modelId || !session.requestInitiator || !session.conversationId) {
+				continue;
+			}
+			if (typeof session.updatedAt !== "number" || now - session.updatedAt > OPENAI_CHAT_REASONING_CACHE_TTL_MS) {
+				continue;
+			}
+			const messages = new Map<string, PersistentReasoningMessageRecord>();
+			for (const entry of session.messages ?? []) {
+				if (!entry?.messageId || !entry.payload || typeof entry.updatedAt !== "number") {
+					continue;
+				}
+				if (now - entry.updatedAt > OPENAI_CHAT_REASONING_CACHE_TTL_MS) {
+					continue;
+				}
+				messages.set(entry.messageId, entry);
+			}
+			if (messages.size === 0) {
+				continue;
+			}
+			this.sessions.set(session.sessionKey, { ...session, messages });
+		}
+
+		const legacy = state.get<PersistentReasoningEntry[]>(PersistentOpenAIChatReasoningCache.LEGACY_STORAGE_KEY, []);
+		for (const entry of legacy) {
 			if (entry?.key && entry?.payload) {
-				this.entries.set(entry.key, entry);
+				this.legacyEntries.set(entry.key, entry);
 			}
 		}
+
+		const indices = state.get<PersistentReasoningIndexRecord[]>(PersistentOpenAIChatReasoningCache.INDEX_STORAGE_KEY, []);
+		for (const entry of indices) {
+			if (!entry?.key || !entry.sessionKey || !entry.messageId || typeof entry.updatedAt !== "number") {
+				continue;
+			}
+			if (now - entry.updatedAt > OPENAI_CHAT_REASONING_CACHE_TTL_MS) {
+				continue;
+			}
+			this.indices.set(entry.key, entry);
+		}
+		this.pruneInMemory();
 	}
 
 	recall(
+		modelId: string,
+		requestInitiator: string,
+		conversationId: string,
+		messageId: string
+	): string {
+		const sessionKey = this.buildSessionKey(modelId, requestInitiator, conversationId);
+		const entry = this.touchSessionMessage(sessionKey, messageId);
+		if (!entry) {
+			return "";
+		}
+		try {
+			return this.decodePayload(entry.payload);
+		} catch {
+			this.removeMessage(sessionKey, messageId);
+			void this.flush();
+			return "";
+		}
+	}
+
+	recallLegacy(
 		modelId: string,
 		requestInitiator: string,
 		prefixMessages: readonly LanguageModelChatRequestMessage[],
@@ -832,16 +1381,30 @@ class PersistentOpenAIChatReasoningCache {
 			assistantText,
 			toolCalls
 		);
-		const matchedKey = this.entries.has(key) ? key : this.entries.has(fallbackKey) ? fallbackKey : "";
-		const entry = matchedKey ? this.entries.get(matchedKey) : undefined;
+		const indexed = this.indices.get(key) ?? this.indices.get(fallbackKey);
+		if (indexed) {
+			const entry = this.touchSessionMessage(indexed.sessionKey, indexed.messageId);
+			if (entry) {
+				try {
+					return this.decodePayload(entry.payload);
+				} catch {
+					this.removeMessage(indexed.sessionKey, indexed.messageId);
+					void this.flush();
+					return "";
+				}
+			}
+			this.indices.delete(indexed.key);
+			void this.flush();
+		}
+		const matchedKey = this.legacyEntries.has(key) ? key : this.legacyEntries.has(fallbackKey) ? fallbackKey : "";
+		const entry = matchedKey ? this.legacyEntries.get(matchedKey) : undefined;
 		if (!entry) {
 			return "";
 		}
 		try {
-			return gunzipSync(Buffer.from(entry.payload, "base64url")).toString("utf8");
+			return this.decodePayload(entry.payload);
 		} catch {
-			this.entries.delete(matchedKey);
-			void this.flush();
+			this.legacyEntries.delete(matchedKey);
 			return "";
 		}
 	}
@@ -849,50 +1412,180 @@ class PersistentOpenAIChatReasoningCache {
 	async remember(
 		modelId: string,
 		requestInitiator: string,
-		prefixMessages: readonly LanguageModelChatRequestMessage[],
-		assistantText: string,
-		toolCalls: readonly OpenAIChatToolCallSignature[],
-		reasoning: string
+		conversationId: string,
+		messageId: string,
+		reasoning: string,
+		prefixMessages?: readonly LanguageModelChatRequestMessage[],
+		assistantText?: string,
+		toolCalls?: readonly OpenAIChatToolCallSignature[]
 	): Promise<void> {
-		const key = buildOpenAIChatReasoningTurnCacheKey(
-			modelId,
-			requestInitiator,
-			prefixMessages,
-			assistantText,
-			toolCalls
-		);
-		const fallbackKey = buildOpenAIChatReasoningFallbackCacheKey(
-			modelId,
-			requestInitiator,
-			assistantText,
-			toolCalls
-		);
+		const sessionKey = this.buildSessionKey(modelId, requestInitiator, conversationId);
+		const now = Date.now();
 		const payload = gzipSync(reasoning).toString("base64url");
-		const upsert = (entryKey: string) => {
-			if (this.entries.has(entryKey)) {
-				this.entries.delete(entryKey);
-			}
-			this.entries.set(entryKey, { key: entryKey, payload, updatedAt: Date.now() });
-		};
-		upsert(key);
-		if (fallbackKey !== key) {
-			upsert(fallbackKey);
+		let session = this.sessions.get(sessionKey);
+		if (!session) {
+			session = {
+				sessionKey,
+				modelId,
+				requestInitiator,
+				conversationId,
+				updatedAt: now,
+				messages: new Map<string, PersistentReasoningMessageRecord>(),
+			};
+			this.sessions.set(sessionKey, session);
 		}
-		while (this.entries.size > OPENAI_CHAT_REASONING_CACHE_LIMIT) {
-			const oldestKey = this.entries.keys().next().value;
-			if (!oldestKey) {
+		session.updatedAt = now;
+		if (session.messages.has(messageId)) {
+			session.messages.delete(messageId);
+		}
+		session.messages.set(messageId, { messageId, payload, updatedAt: now });
+		if (prefixMessages && assistantText !== undefined && toolCalls) {
+			const keys = new Set([
+				buildOpenAIChatReasoningTurnCacheKey(modelId, requestInitiator, prefixMessages, assistantText, toolCalls),
+				buildOpenAIChatReasoningFallbackCacheKey(modelId, requestInitiator, assistantText, toolCalls),
+			]);
+			for (const key of keys) {
+				this.indices.set(key, { key, sessionKey, messageId, updatedAt: now });
+			}
+		}
+		this.pruneInMemory();
+		await this.flush();
+	}
+
+	private buildSessionKey(modelId: string, requestInitiator: string, conversationId: string): string {
+		return stableStringify({ modelId, requestInitiator, conversationId });
+	}
+
+	private touchSessionMessage(sessionKey: string, messageId: string): PersistentReasoningMessageRecord | null {
+		const session = this.sessions.get(sessionKey);
+		if (!session) {
+			return null;
+		}
+		const entry = session.messages.get(messageId);
+		if (!entry) {
+			return null;
+		}
+		const updatedAt = Date.now();
+		const nextEntry = { ...entry, updatedAt };
+		session.messages.delete(messageId);
+		session.messages.set(messageId, nextEntry);
+		session.updatedAt = updatedAt;
+		for (const index of this.indices.values()) {
+			if (index.sessionKey === sessionKey && index.messageId === messageId) {
+				index.updatedAt = updatedAt;
+			}
+		}
+		return nextEntry;
+	}
+
+	private removeMessage(sessionKey: string, messageId: string): void {
+		const session = this.sessions.get(sessionKey);
+		if (session) {
+			session.messages.delete(messageId);
+			if (session.messages.size === 0) {
+				this.sessions.delete(sessionKey);
+			}
+		}
+		for (const [key, index] of this.indices) {
+			if (index.sessionKey === sessionKey && index.messageId === messageId) {
+				this.indices.delete(key);
+			}
+		}
+	}
+
+	private removeSession(sessionKey: string): void {
+		this.sessions.delete(sessionKey);
+		for (const [key, index] of this.indices) {
+			if (index.sessionKey === sessionKey) {
+				this.indices.delete(key);
+			}
+		}
+	}
+
+	private decodePayload(payload: string): string {
+		return gunzipSync(Buffer.from(payload, "base64url")).toString("utf8");
+	}
+
+	private pruneInMemory(): void {
+		const now = Date.now();
+		for (const [sessionKey, session] of this.sessions) {
+			if (now - session.updatedAt > OPENAI_CHAT_REASONING_CACHE_TTL_MS) {
+				this.removeSession(sessionKey);
+				continue;
+			}
+			for (const [messageId, entry] of session.messages) {
+				if (now - entry.updatedAt > OPENAI_CHAT_REASONING_CACHE_TTL_MS) {
+					this.removeMessage(sessionKey, messageId);
+				}
+			}
+			while (session.messages.size > OPENAI_CHAT_REASONING_CACHE_SESSION_LIMIT) {
+				const oldestMessageId = session.messages.keys().next().value;
+				if (!oldestMessageId) {
+					break;
+				}
+				this.removeMessage(sessionKey, oldestMessageId);
+			}
+			if (session.messages.size === 0) {
+				this.removeSession(sessionKey);
+			}
+		}
+
+		for (const [key, index] of this.indices) {
+			if (now - index.updatedAt > OPENAI_CHAT_REASONING_CACHE_TTL_MS) {
+				this.indices.delete(key);
+				continue;
+			}
+			const session = this.sessions.get(index.sessionKey);
+			if (!session || !session.messages.has(index.messageId)) {
+				this.indices.delete(key);
+			}
+		}
+
+		while (this.totalMessageCount() > OPENAI_CHAT_REASONING_CACHE_TOTAL_LIMIT) {
+			const oldest = this.findOldestMessage();
+			if (!oldest) {
 				break;
 			}
-			this.entries.delete(oldestKey);
+			const session = this.sessions.get(oldest.sessionKey);
+			if (!session) {
+				break;
+			}
+			this.removeMessage(oldest.sessionKey, oldest.messageId);
 		}
-		await this.flush();
+	}
+
+	private totalMessageCount(): number {
+		let total = 0;
+		for (const session of this.sessions.values()) {
+			total += session.messages.size;
+		}
+		return total;
+	}
+
+	private findOldestMessage(): { sessionKey: string; messageId: string; updatedAt: number } | null {
+		let oldest: { sessionKey: string; messageId: string; updatedAt: number } | null = null;
+		for (const [sessionKey, session] of this.sessions) {
+			for (const [messageId, entry] of session.messages) {
+				if (!oldest || entry.updatedAt < oldest.updatedAt) {
+					oldest = { sessionKey, messageId, updatedAt: entry.updatedAt };
+				}
+			}
+		}
+		return oldest;
 	}
 
 	private async flush(): Promise<void> {
 		await this.state.update(
 			PersistentOpenAIChatReasoningCache.STORAGE_KEY,
-			Array.from(this.entries.values())
+			Array.from(this.sessions.values()).map((session) => ({
+				sessionKey: session.sessionKey,
+				modelId: session.modelId,
+				requestInitiator: session.requestInitiator,
+				conversationId: session.conversationId,
+				updatedAt: session.updatedAt,
+				messages: Array.from(session.messages.values()),
+			}))
 		);
+		await this.state.update(PersistentOpenAIChatReasoningCache.INDEX_STORAGE_KEY, Array.from(this.indices.values()));
 	}
 }
-

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,6 +184,10 @@ export function isImageMimeType(mimeType: string): boolean {
 	return mimeType.startsWith("image/") && ["image/jpeg", "image/png", "image/gif", "image/webp"].includes(mimeType);
 }
 
+export function isInternalMarkerMimeType(mimeType: string): boolean {
+	return mimeType.startsWith("application/vnd.oaicopilot.");
+}
+
 /**
  * 创建图片的data URL
  */
@@ -218,6 +222,8 @@ export function collectToolResultText(pr: { content?: ReadonlyArray<unknown> }):
 		} else if (typeof c === "string") {
 			text += c;
 		} else if (c instanceof vscode.LanguageModelDataPart && c.mimeType === "cache_control") {
+			/* ignore */
+		} else if (c instanceof vscode.LanguageModelDataPart && isInternalMarkerMimeType(c.mimeType)) {
 			/* ignore */
 		} else {
 			try {


### PR DESCRIPTION
## 摘要

修复 OpenAI-compatible `/chat/completions` 下的 preserved reasoning replay，已确认影响 `glm-5.1`。

该修复会持久化 assistant reasoning，并在后续轮次及重启后为 replay 的 assistant 消息恢复 `reasoning_content`。同时修正了多配置场景下的错误回退，避免 reasoning 泄漏到 `include_reasoning_in_request=false` 的配置。

## 改动

- 为 `/chat/completions` 增加本地 reasoning 持久化与恢复
- 仅在存在真实 reasoning 时发送 `reasoning_content`
- 禁止带 `configId` 的模型回退到同 base id 的其他配置
- 为 reasoning replay 与 tool replay 增加回归测试
- 更新 README 中相关配置与验证说明

## 验证

已通过以下验证：

- `npm run compile`
- `node scripts/verify_persistent_reasoning_restart.mjs`
- `node scripts/verify_tool_reasoning_shape.mjs`
- `npm run verify:reasoning-tools`

另外，基于真实 `glm-5.1` 会话抓包确认：
replayed assistant turn 的实际 `/chat/completions` 请求中已包含 `reasoning_content`。