### PR TITLE
feat: make User-Agent configurable with master switch setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,6 +442,11 @@
 					"minimum": 0,
 					"maximum": 10000,
 					"description": "Number of lines to read when using `read_file` tool. Large lines may cost more tokens. Default is 0, let model decide lines."
+				},
+				"oaicopilot.useBrowserUserAgent": {
+					"type": "boolean",
+					"default": false,
+					"description": "Use a browser-like User-Agent string to avoid Cloudflare 1010 errors. When enabled, requests will use a Chrome User-Agent instead of the default extension identifier."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -446,7 +446,12 @@
 				"oaicopilot.useBrowserUserAgent": {
 					"type": "boolean",
 					"default": false,
-					"description": "Use a browser-like User-Agent string to avoid Cloudflare 1010 errors. When enabled, requests will use a Chrome User-Agent instead of the default extension identifier."
+					"description": "Master switch for custom User-Agent. When disabled, always uses the default extension identifier. When enabled, uses customUserAgent if set, otherwise uses a Chrome-like User-Agent."
+				},
+				"oaicopilot.customUserAgent": {
+					"type": "string",
+					"default": "",
+					"description": "Custom User-Agent string for API requests. Only used when useBrowserUserAgent is enabled. Leave empty to use the default Chrome User-Agent."
 				}
 			}
 		}

--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -16,22 +16,28 @@ export class VersionManager {
 
 	/**
 	 * Build a User-Agent for API requests.
-	 * By default, uses the extension identifier. When useBrowserUserAgent setting is enabled,
-	 * uses a Chrome-like User-Agent to avoid Cloudflare 1010 blocking.
+	 * Master switch: useBrowserUserAgent
+	 * - When false: Always use default extension identifier UA
+	 * - When true: Use customUserAgent if set, otherwise Chrome-like UA
 	 */
 	static getUserAgent(): string {
 		const config = vscode.workspace.getConfiguration("oaicopilot");
 		const useBrowserUA = config.get<boolean>("useBrowserUserAgent", false);
 
-		if (useBrowserUA) {
-			// Use a standard Chrome User-Agent to avoid Cloudflare 1010 errors
-			// that block non-browser signatures
-			return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.0";
+		// Master switch off: always use default extension UA
+		if (!useBrowserUA) {
+			const vscodeVersion = vscode.version;
+			return `oai-compatible-copilot/${this.getVersion()} VSCode/${vscodeVersion}`;
 		}
 
-		// Default: use extension identifier
-		const vscodeVersion = vscode.version;
-		return `oai-compatible-copilot/${this.getVersion()} VSCode/${vscodeVersion}`;
+		// Master switch on: check for custom UA first
+		const customUA = config.get<string>("customUserAgent", "");
+		if (customUA && customUA.trim()) {
+			return customUA.trim();
+		}
+
+		// Fallback to Chrome User-Agent to avoid Cloudflare 1010 errors
+		return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.0";
 	}
 
 	/**

--- a/src/versionManager.ts
+++ b/src/versionManager.ts
@@ -15,10 +15,21 @@ export class VersionManager {
 	}
 
 	/**
-	 * Build a descriptive User-Agent to help quantify API usage
-	 * Keep UA minimal: only extension version and VS Code version
+	 * Build a User-Agent for API requests.
+	 * By default, uses the extension identifier. When useBrowserUserAgent setting is enabled,
+	 * uses a Chrome-like User-Agent to avoid Cloudflare 1010 blocking.
 	 */
 	static getUserAgent(): string {
+		const config = vscode.workspace.getConfiguration("oaicopilot");
+		const useBrowserUA = config.get<boolean>("useBrowserUserAgent", false);
+
+		if (useBrowserUA) {
+			// Use a standard Chrome User-Agent to avoid Cloudflare 1010 errors
+			// that block non-browser signatures
+			return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.0";
+		}
+
+		// Default: use extension identifier
 		const vscodeVersion = vscode.version;
 		return `oai-compatible-copilot/${this.getVersion()} VSCode/${vscodeVersion}`;
 	}


### PR DESCRIPTION
## Summary

This PR makes the User-Agent string configurable through extension settings.

### Changes

1. **Browser-like User-Agent** : Uses Chrome UA to avoid Cloudflare 1010 blocking
2. **Configurable User-Agent** : Adds customUserAgent setting with useBrowserUserAgent as master switch

### Settings

- oaicopilot.useBrowserUserAgent - Master switch (default: off)
  - Off: Always uses default extension identifier UA
  - On: Uses customUserAgent if set, otherwise Chrome UA
- oaicopilot.customUserAgent - Custom User-Agent string (only used when master switch is on)

### Commits

- fix: use browser-like User-Agent to avoid Cloudflare 1010 blocking
- feat: make User-Agent configurable with master switch setting

### Screenshots
Here's the test for OpenCode Zen Go service, it seemed to have blocked this extension's user aggent but vscode insider was fine, and using generic browser user agent was fine, too.

<img width="612" height="980" alt="PixPin_2026-04-13_05-09-24" src="https://github.com/user-attachments/assets/8f89eda2-803c-4fd1-8ef5-f4f1ecb46c0f" />

<img width="924" height="136" alt="PixPin_2026-04-13_05-10-09" src="https://github.com/user-attachments/assets/0cd471ce-e877-405f-8427-b068631bd7e0" />

<img width="619" height="239" alt="PixPin_2026-04-13_05-10-38" src="https://github.com/user-attachments/assets/9f5adeec-943e-4c8e-8bec-7f2c64b3f402" />

