### PR TITLE
Add Copilot reasoning effort picker support

### DIFF
--- a/assets/configView/configView.html
+++ b/assets/configView/configView.html
@@ -354,7 +354,7 @@
 								</div>
 								<div class="field">
 									<label for="modelReasoningEffort">Reasoning Effort (OpenAI)</label>
-									<div class="field-description">Include "reasoning_effort" in request body.</div>
+									<div class="field-description">Default OpenAI reasoning effort. Leave empty to hide the Copilot picker.</div>
 									<select id="modelReasoningEffort" class="model-input">
 										<option value=""></option>
 										<option value="max">Max</option>

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
 									"low",
 									"minimal"
 								],
-								"description": "Reasoning effort level (OpenAI reasoning configuration)"
+								"description": "Default reasoning effort level for OpenAI-compatible requests. Leave empty to hide the Copilot picker."
 							},
 							"thinking": {
 								"type": "object",

--- a/src/modelConfiguration.ts
+++ b/src/modelConfiguration.ts
@@ -1,0 +1,81 @@
+import type * as vscode from "vscode";
+import type { HFModelItem } from "./types";
+
+export type ReasoningEffortPickerValue = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+const REASONING_EFFORT_VALUES: readonly ReasoningEffortPickerValue[] = [
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+];
+
+export const REASONING_EFFORT_CONFIGURATION_SCHEMA = {
+	properties: {
+		reasoningEffort: {
+			type: "string",
+			title: "Reasoning Effort",
+			enum: REASONING_EFFORT_VALUES,
+			enumItemLabels: ["Minimal", "Low", "Medium", "High", "XHigh", "Max"],
+			enumDescriptions: [
+				"Smallest reasoning budget",
+				"Low reasoning budget",
+				"Balanced reasoning budget",
+				"High reasoning budget",
+				"Very high reasoning budget",
+				"Maximum reasoning budget",
+			],
+			default: "medium",
+			group: "navigation",
+		},
+	},
+} as const;
+
+export function createReasoningEffortConfigurationSchema(defaultValue: ReasoningEffortPickerValue) {
+	return {
+		properties: {
+			reasoningEffort: {
+				...REASONING_EFFORT_CONFIGURATION_SCHEMA.properties.reasoningEffort,
+				default: defaultValue,
+			},
+		},
+	} as const;
+}
+
+export type ModelConfigurationOptions = vscode.ProvideLanguageModelChatResponseOptions & {
+	readonly modelConfiguration?: Record<string, unknown>;
+	readonly configuration?: Record<string, unknown>;
+};
+
+export type ModelPickerChatInformation = vscode.LanguageModelChatInformation & {
+	readonly isUserSelectable?: boolean;
+	readonly detail?: string;
+	readonly tooltip?: string;
+	readonly configurationSchema?: ReturnType<typeof createReasoningEffortConfigurationSchema>;
+};
+
+export function isReasoningEffortPickerEnabled(
+	model: HFModelItem | undefined
+): model is HFModelItem & { reasoning_effort: ReasoningEffortPickerValue } {
+	return isReasoningEffortValue(model?.reasoning_effort);
+}
+
+export function getConfiguredReasoningEffort(
+	options: vscode.ProvideLanguageModelChatResponseOptions | undefined,
+	fallback: ReasoningEffortPickerValue = "medium"
+): ReasoningEffortPickerValue {
+	const modelOptions = options as ModelConfigurationOptions | undefined;
+	const configuredEffort =
+		modelOptions?.modelConfiguration?.reasoningEffort ?? modelOptions?.configuration?.reasoningEffort;
+
+	if (isReasoningEffortValue(configuredEffort)) {
+		return configuredEffort;
+	}
+	return fallback;
+}
+
+export function isReasoningEffortValue(value: unknown): value is ReasoningEffortPickerValue {
+	return typeof value === "string" && REASONING_EFFORT_VALUES.includes(value as ReasoningEffortPickerValue);
+}

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -8,6 +8,7 @@ import {
 } from "vscode";
 
 import type { HFModelItem, ReasoningConfig, TokenUsage } from "../types";
+import { getConfiguredReasoningEffort, isReasoningEffortPickerEnabled } from "../modelConfiguration";
 
 import type {
 	OpenAIChatMessage,
@@ -172,7 +173,9 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 		}
 
 		// OpenAI reasoning configuration
-		if (um?.reasoning_effort !== undefined) {
+		if (isReasoningEffortPickerEnabled(um)) {
+			rb.reasoning_effort = getConfiguredReasoningEffort(options, um.reasoning_effort);
+		} else if (um?.reasoning_effort !== undefined) {
 			rb.reasoning_effort = um.reasoning_effort;
 		}
 

--- a/src/openai/openaiResponsesApi.ts
+++ b/src/openai/openaiResponsesApi.ts
@@ -8,6 +8,7 @@ import {
 } from "vscode";
 
 import type { HFModelItem } from "../types";
+import { getConfiguredReasoningEffort, isReasoningEffortPickerEnabled } from "../modelConfiguration";
 import type { OpenAIToolCall } from "./openaiTypes";
 
 import {
@@ -236,7 +237,13 @@ export class OpenaiResponsesApi extends CommonApi<ResponsesInputItem, Record<str
 		}
 
 		// OpenAI reasoning configuration
-		if (um?.reasoning_effort !== undefined) {
+		if (isReasoningEffortPickerEnabled(um)) {
+			const existing = isPlainObject(rb.reasoning) ? { ...(rb.reasoning as Record<string, unknown>) } : {};
+			rb.reasoning = {
+				...existing,
+				effort: getConfiguredReasoningEffort(options, um.reasoning_effort),
+			};
+		} else if (um?.reasoning_effort !== undefined) {
 			const existing = isPlainObject(rb.reasoning) ? { ...(rb.reasoning as Record<string, unknown>) } : {};
 			rb.reasoning = {
 				...existing,

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -2,6 +2,11 @@ import * as vscode from "vscode";
 import { CancellationToken, LanguageModelChatInformation } from "vscode";
 
 import type { HFApiMode, HFModelItem, HFModelsResponse } from "./types";
+import {
+	createReasoningEffortConfigurationSchema,
+	type ModelPickerChatInformation,
+	isReasoningEffortValue,
+} from "./modelConfiguration";
 import { normalizeUserModels } from "./utils";
 import { VersionManager } from "./versionManager";
 import { fetchGeminiModels } from "./gemini/geminiApi";
@@ -27,7 +32,7 @@ export async function prepareLanguageModelChatInformation(
 	const config = vscode.workspace.getConfiguration();
 	const userModels = normalizeUserModels(config.get<unknown>("oaicopilot.models", []));
 
-	let infos: LanguageModelChatInformation[];
+	let infos: ModelPickerChatInformation[];
 	if (userModels && userModels.length > 0) {
 		// Return user-provided models directly
 		infos = userModels
@@ -37,10 +42,11 @@ export async function prepareLanguageModelChatInformation(
 				const maxOutput = m?.max_completion_tokens ?? m?.max_tokens ?? DEFAULT_MAX_TOKENS;
 				const maxInput = Math.max(1, contextLen - maxOutput);
 
-				// 使用配置ID（如果存在）来生成唯一的模型ID
+				// Keep the model identifier unique while keeping the picker label readable.
 				const modelId = m.configId ? `${m.id}::${m.configId}` : m.id;
-				const modelName = m.displayName || (m.configId ? `${m.id}::${m.configId}` : `${m.id}`);
+				const modelName = m.displayName || `${m.id}`;
 				const detail = m.owned_by ? `${m.owned_by} (${EXTENSION_LABEL})` : EXTENSION_LABEL;
+				const reasoningEffort = isReasoningEffortValue(m.reasoning_effort) ? m.reasoning_effort : undefined;
 
 				return {
 					id: modelId,
@@ -52,11 +58,14 @@ export async function prepareLanguageModelChatInformation(
 					maxInputTokens: maxInput,
 					maxOutputTokens: maxOutput,
 					isUserSelectable: true,
+					...(reasoningEffort
+						? { configurationSchema: createReasoningEffortConfigurationSchema(reasoningEffort) }
+						: {}),
 					capabilities: {
 						toolCalling: true,
 						imageInput: m?.vision ?? false,
 					},
-				} satisfies LanguageModelChatInformation;
+				} satisfies ModelPickerChatInformation;
 			});
 	} else {
 		// Fallback: Fetch models from API
@@ -83,7 +92,7 @@ export async function prepareLanguageModelChatInformation(
 
 			// Build entries for all providers that support tool calling
 			const toolProviders = providers.filter((p) => p.supports_tools === true);
-			const entries: LanguageModelChatInformation[] = [];
+			const entries: ModelPickerChatInformation[] = [];
 
 			for (const p of toolProviders) {
 				const contextLen = p?.context_length ?? DEFAULT_CONTEXT_LENGTH;

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -42,9 +42,9 @@ export async function prepareLanguageModelChatInformation(
 				const maxOutput = m?.max_completion_tokens ?? m?.max_tokens ?? DEFAULT_MAX_TOKENS;
 				const maxInput = Math.max(1, contextLen - maxOutput);
 
-				// Keep the model identifier unique while keeping the picker label readable.
+				// Use configId when present so each model configuration stays distinct.
 				const modelId = m.configId ? `${m.id}::${m.configId}` : m.id;
-				const modelName = m.displayName || `${m.id}`;
+				const modelName = m.displayName || (m.configId ? `${m.id}::${m.configId}` : `${m.id}`);
 				const detail = m.owned_by ? `${m.owned_by} (${EXTENSION_LABEL})` : EXTENSION_LABEL;
 				const reasoningEffort = isReasoningEffortValue(m.reasoning_effort) ? m.reasoning_effort : undefined;
 

--- a/src/test/modelConfiguration.test.ts
+++ b/src/test/modelConfiguration.test.ts
@@ -1,0 +1,167 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { AnthropicApi } from "../anthropic/anthropicApi";
+import { GeminiApi } from "../gemini/geminiApi";
+import {
+	createReasoningEffortConfigurationSchema,
+	getConfiguredReasoningEffort,
+	isReasoningEffortPickerEnabled,
+	type ModelPickerChatInformation,
+	REASONING_EFFORT_CONFIGURATION_SCHEMA,
+} from "../modelConfiguration";
+import { OllamaApi } from "../ollama/ollamaApi";
+import { OpenaiApi } from "../openai/openaiApi";
+import { OpenaiResponsesApi } from "../openai/openaiResponsesApi";
+import { prepareLanguageModelChatInformation } from "../provideModel";
+import type { HFModelItem } from "../types";
+
+suite("modelConfiguration", () => {
+	const deepSeekModel: HFModelItem = {
+		id: "deepseek-v4-pro",
+		displayName: "DeepSeek V4 Pro",
+		owned_by: "deepseek",
+		baseUrl: "https://api.deepseek.com",
+		apiMode: "openai",
+		context_length: 1_000_000,
+		max_tokens: 384_000,
+		reasoning_effort: "medium",
+	};
+
+	test("only enables the picker when the model has a reasoning effort default", () => {
+		assert.strictEqual(isReasoningEffortPickerEnabled({ id: "m", owned_by: "p" }), false);
+		assert.strictEqual(isReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning_effort: "" }), false);
+		assert.strictEqual(isReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning_effort: "custom" }), false);
+		assert.strictEqual(isReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning_effort: "high" }), true);
+	});
+
+	test("defines reasoning effort choices for provider configuration", () => {
+		const schema = REASONING_EFFORT_CONFIGURATION_SCHEMA.properties.reasoningEffort;
+		assert.strictEqual(schema.title, "Reasoning Effort");
+		assert.strictEqual(schema.default, "medium");
+		assert.deepStrictEqual(schema.enum, ["minimal", "low", "medium", "high", "xhigh", "max"]);
+		assert.strictEqual(createReasoningEffortConfigurationSchema("high").properties.reasoningEffort.default, "high");
+	});
+
+	test("reads the selected reasoning effort from VS Code model configuration", () => {
+		assert.strictEqual(getConfiguredReasoningEffort(undefined), "medium");
+		assert.strictEqual(getConfiguredReasoningEffort(undefined, "low"), "low");
+		assert.strictEqual(getConfiguredReasoningEffort({ modelConfiguration: { reasoningEffort: "high" } } as never), "high");
+		assert.strictEqual(getConfiguredReasoningEffort({ configuration: { reasoningEffort: "max" } } as never), "max");
+		assert.strictEqual(
+			getConfiguredReasoningEffort({ modelConfiguration: { reasoningEffort: "invalid" } } as never, "xhigh"),
+			"xhigh"
+		);
+	});
+
+	test("registers deepseek-v4-flash with reasoning effort metadata", async () => {
+		const config = vscode.workspace.getConfiguration();
+		const previousModels = config.get<unknown>("oaicopilot.models", []);
+		const cts = new vscode.CancellationTokenSource();
+		const model: HFModelItem = { ...deepSeekModel, id: "deepseek-v4-flash", displayName: undefined };
+
+		try {
+			await config.update("oaicopilot.models", [model], vscode.ConfigurationTarget.Global);
+
+			const infos = await prepareLanguageModelChatInformation(
+				{ silent: true },
+				cts.token,
+				{} as vscode.SecretStorage
+			);
+			const info = infos.find((item) => item.id === "deepseek-v4-flash") as ModelPickerChatInformation | undefined;
+
+			assert.ok(info, "deepseek-v4-flash should be registered");
+			assert.strictEqual(info.name, "deepseek-v4-flash");
+			assert.strictEqual(info.detail, "deepseek (OAICopilot)");
+			assert.strictEqual(info.isUserSelectable, true);
+			assert.deepStrictEqual(info.configurationSchema, createReasoningEffortConfigurationSchema("medium"));
+		} finally {
+			cts.dispose();
+			await config.update("oaicopilot.models", previousModels, vscode.ConfigurationTarget.Global);
+		}
+	});
+
+	test("does not register reasoning effort metadata when the default is empty", async () => {
+		const config = vscode.workspace.getConfiguration();
+		const previousModels = config.get<unknown>("oaicopilot.models", []);
+		const cts = new vscode.CancellationTokenSource();
+		const model: HFModelItem = {
+			...deepSeekModel,
+			id: "deepseek-v4-flash",
+			displayName: undefined,
+			reasoning_effort: undefined,
+		};
+
+		try {
+			await config.update("oaicopilot.models", [model], vscode.ConfigurationTarget.Global);
+
+			const infos = await prepareLanguageModelChatInformation(
+				{ silent: true },
+				cts.token,
+				{} as vscode.SecretStorage
+			);
+			const info = infos.find((item) => item.id === "deepseek-v4-flash") as ModelPickerChatInformation | undefined;
+
+			assert.ok(info, "deepseek-v4-flash should be registered");
+			assert.strictEqual(info.configurationSchema, undefined);
+		} finally {
+			cts.dispose();
+			await config.update("oaicopilot.models", previousModels, vscode.ConfigurationTarget.Global);
+		}
+	});
+
+	test("applies selected reasoning effort to OpenAI-compatible chat requests", () => {
+		const requestBody = new OpenaiApi("deepseek-v4-pro").prepareRequestBody(
+			{ model: "deepseek-v4-pro", messages: [], stream: true },
+			deepSeekModel,
+			{ modelConfiguration: { reasoningEffort: "high" } } as never
+		);
+
+		assert.strictEqual(requestBody.reasoning_effort, "high");
+	});
+
+	test("falls back to the configured default reasoning effort when Copilot has no temporary override", () => {
+		const requestBody = new OpenaiApi("deepseek-v4-pro").prepareRequestBody(
+			{ model: "deepseek-v4-pro", messages: [], stream: true },
+			{ ...deepSeekModel, reasoning_effort: "low" },
+			undefined
+		);
+
+		assert.strictEqual(requestBody.reasoning_effort, "low");
+	});
+
+	test("applies selected reasoning effort to OpenAI Responses requests", () => {
+		const requestBody = new OpenaiResponsesApi("deepseek-v4-pro").prepareRequestBody(
+			{ model: "deepseek-v4-pro", input: [], stream: true },
+			{ ...deepSeekModel, apiMode: "openai-responses" },
+			{ modelConfiguration: { reasoningEffort: "max" } } as never
+		);
+
+		assert.deepStrictEqual(requestBody.reasoning, { effort: "max" });
+	});
+
+	test("keeps the picker out of unsupported native API request bodies", () => {
+		const options = { modelConfiguration: { reasoningEffort: "high" } } as never;
+		const anthropicBody = new AnthropicApi("claude").prepareRequestBody(
+			{ model: "claude", messages: [], max_tokens: 1024, stream: true },
+			{ ...deepSeekModel, apiMode: "anthropic" },
+			options
+		) as unknown as Record<string, unknown>;
+		const ollamaBody = new OllamaApi("qwen3").prepareRequestBody(
+			{ model: "qwen3", messages: [], stream: true },
+			{ ...deepSeekModel, apiMode: "ollama" },
+			options
+		) as unknown as Record<string, unknown>;
+		const geminiBody = new GeminiApi("gemini").prepareRequestBody(
+			{ contents: [] },
+			{ ...deepSeekModel, apiMode: "gemini" },
+			options
+		) as Record<string, unknown>;
+
+		assert.strictEqual(anthropicBody.reasoning_effort, undefined);
+		assert.strictEqual(anthropicBody.thinking, undefined);
+		assert.strictEqual(ollamaBody.reasoning_effort, undefined);
+		assert.strictEqual(ollamaBody.think, undefined);
+		assert.strictEqual(geminiBody.reasoning_effort, undefined);
+		assert.strictEqual(geminiBody.thinkingConfig, undefined);
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds support for exposing VS Code Copilot's per-request `Reasoning Effort` picker for OpenAI-compatible models.

The existing `reasoning_effort` model setting keeps its original meaning as the model-level default reasoning effort. When it is configured, the extension now also exposes a Copilot chat input picker so users can temporarily override the effort for a single request.

This branch has been rebased onto the latest upstream `main`, including the VS Code 1.120.0 compatibility update from #241.

## Behavior

- If `reasoning_effort` is unset or empty:
  - the model is registered normally;
  - no Copilot reasoning effort picker is shown.

- If `reasoning_effort` is set to a supported value:
  - the model is registered with a Copilot `configurationSchema`;
  - the Copilot chat input shows a `Reasoning Effort` picker;
  - the configured `reasoning_effort` value is used as the picker default.

- If the user changes the picker value in Copilot:
  - that temporary selection is used for the current request.

- If Copilot does not pass a temporary picker value:
  - the configured model-level `reasoning_effort` is used as the fallback.

## Implementation

The implementation adds a small model configuration helper in `src/modelConfiguration.ts`.

It defines:

- the supported reasoning effort values:
  - `minimal`
  - `low`
  - `medium`
  - `high`
  - `xhigh`
  - `max`

- the Copilot `configurationSchema` used to show the picker;
- a helper for creating the schema with the model's configured `reasoning_effort` as the default value;
- a helper for reading the per-request value from VS Code's model configuration payload.

Model registration in `prepareLanguageModelChatInformation` now checks whether the configured model has a valid `reasoning_effort`.

If it does, the model metadata includes `configurationSchema`, which makes Copilot show the picker. If it does not, the schema is omitted, so Copilot does not show the extra UI.

This also preserves `configId` in the model picker label when no explicit `displayName` is set, so multiple configurations of the same model remain distinguishable.

Request body handling is updated in both OpenAI-compatible paths:

- Chat Completions:
  - writes the selected/default value to `reasoning_effort`

- Responses API:
  - writes the selected/default value to `reasoning.effort`

The change deliberately does not apply OpenAI-style reasoning parameters to native Anthropic, Ollama, or Gemini request bodies, because those providers use different thinking/reasoning parameter shapes.

## UI

The configuration UI keeps the existing `Reasoning Effort (OpenAI)` selector.

Its description now clarifies that leaving the field empty hides the Copilot picker:

> Default OpenAI reasoning effort. Leave empty to hide the Copilot picker.

## Validation

Tested after rebasing onto the latest upstream `main` / VS Code 1.120.0 baseline with:

- `npm run compile`
- `npm run test`
- `npx eslint src/modelConfiguration.ts src/test/modelConfiguration.test.ts src/provideModel.ts`
- `git diff --check upstream/main..HEAD`

The test suite covers:

- picker hidden when `reasoning_effort` is empty;
- picker registered when `reasoning_effort` is configured;
- configured value used as picker default;
- temporary Copilot picker selection overriding the default;
- fallback to configured default when no temporary value is provided;
- OpenAI Chat Completions request body mapping;
- OpenAI Responses request body mapping;
- Anthropic / Ollama / Gemini not receiving OpenAI-style reasoning parameters.

Note: full `npm run lint` still reports pre-existing repository lint issues outside this PR's changed code.
