### PR TITLE
feat(anthropic): enable prompt caching breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Feat(anthropic): Enable prompt caching. The system prompt and the last tool definition are now marked with `cache_control: { type: "ephemeral" }`, and in-message `cache_control` markers emitted by Copilot (`LanguageModelDataPart` with mimeType `"cache_control"`) are forwarded to Anthropic instead of being silently dropped. Add a per-model `cache_control` boolean (default `true`) to disable it for providers that reject the field.
+
 ## 0.4.1 (2026-05-14)
 
 - Feat(usage): Implement token usage reporting for Context Window widget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Feat(anthropic): Enable prompt caching. The system prompt and the last tool definition are now marked with `cache_control: { type: "ephemeral" }`, and in-message `cache_control` markers emitted by Copilot (`LanguageModelDataPart` with mimeType `"cache_control"`) are forwarded to Anthropic instead of being silently dropped. Add a per-model `cache_control` boolean (default `true`) to disable it for providers that reject the field.
+- Fix(anthropic): Cap total `cache_control` breakpoints at 4 per request (Anthropic's hard limit). When Copilot's own in-message breakpoints push the request over the cap, strip earliest in-message ones first, then tools, then system — preserving the highest-value (most recent / largest-prefix) breakpoints.
 
 ## 0.4.1 (2026-05-14)
 

--- a/package.json
+++ b/package.json
@@ -356,6 +356,11 @@
 								"default": 0,
 								"minimum": 0,
 								"description": "Model-specific delay in milliseconds between consecutive requests. If not specified, falls back to global oaicopilot.delay configuration."
+							},
+							"cache_control": {
+								"type": "boolean",
+								"default": true,
+								"description": "Enable Anthropic prompt-caching breakpoints (apiMode='anthropic' only). When true, attaches cache_control={type:'ephemeral'} to the system prompt and the last tool definition, and forwards any in-message cache_control markers emitted by Copilot. Set to false for upstream providers that reject the cache_control field."
 							}
 						},
 						"required": [

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -13,6 +13,8 @@ import type {
 	AnthropicMessage,
 	AnthropicRequestBody,
 	AnthropicContentBlock,
+	AnthropicCacheControl,
+	AnthropicTextBlock,
 	AnthropicToolUseBlock,
 	AnthropicToolResultBlock,
 	AnthropicStreamChunk,
@@ -24,8 +26,42 @@ import { CommonApi } from "../commonApi";
 import { logger } from "../logger";
 
 export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBody> {
-	constructor(modelId: string) {
+	/**
+	 * Whether Anthropic prompt-caching breakpoints should be emitted on system / tools / messages.
+	 * When false, behave like prior versions (no `cache_control` anywhere in the request).
+	 */
+	private readonly _cacheControlEnabled: boolean;
+
+	constructor(modelId: string, cacheControlEnabled = true) {
 		super(modelId);
+		this._cacheControlEnabled = cacheControlEnabled;
+	}
+
+	/**
+	 * Decode a `LanguageModelDataPart` whose `mimeType` is `"cache_control"` into a real
+	 * Anthropic `cache_control` value. The host (Copilot) encodes the breakpoint payload as a
+	 * UTF-8 JSON string (e.g. `{"type":"ephemeral"}`). Falls back to `{type:"ephemeral"}` if
+	 * the payload is empty or malformed.
+	 */
+	private decodeCacheControlPart(part: vscode.LanguageModelDataPart): AnthropicCacheControl {
+		const fallback: AnthropicCacheControl = { type: "ephemeral" };
+		try {
+			const text = new TextDecoder().decode(part.data);
+			if (!text) {
+				return fallback;
+			}
+			const parsed = JSON.parse(text) as { type?: string; ttl?: string };
+			if (parsed && typeof parsed === "object" && parsed.type === "ephemeral") {
+				const cc: AnthropicCacheControl = { type: "ephemeral" };
+				if (parsed.ttl === "1h" || parsed.ttl === "5m") {
+					cc.ttl = parsed.ttl;
+				}
+				return cc;
+			}
+		} catch {
+			/* fall through */
+		}
+		return fallback;
 	}
 
 	/**
@@ -47,12 +83,28 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			const toolCalls: AnthropicToolUseBlock[] = [];
 			const toolResults: AnthropicToolResultBlock[] = [];
 			const thinkingParts: string[] = [];
+			// Cache breakpoints emitted by the host (Copilot) via LanguageModelDataPart(mimeType="cache_control").
+			// We mark the position in the constructed content-block list where each breakpoint should land.
+			// Breakpoints appearing before any other content fall back to the first block; after-all
+			// breakpoints fall back to the last block. Multiple breakpoints in the same message are honored,
+			// each attached to the latest block at the time the marker was seen.
+			const pendingCacheControls: { afterPartIndex: number; cc: AnthropicCacheControl }[] = [];
+			let collectedParts = 0;
 
 			for (const part of m.content ?? []) {
 				if (part instanceof vscode.LanguageModelTextPart) {
 					textParts.push(part.value);
+					collectedParts++;
+				} else if (part instanceof vscode.LanguageModelDataPart && part.mimeType === "cache_control") {
+					if (this._cacheControlEnabled) {
+						pendingCacheControls.push({
+							afterPartIndex: collectedParts,
+							cc: this.decodeCacheControlPart(part),
+						});
+					}
 				} else if (part instanceof vscode.LanguageModelDataPart && isImageMimeType(part.mimeType)) {
 					imageParts.push(part);
+					collectedParts++;
 				} else if (part instanceof vscode.LanguageModelToolCallPart) {
 					const id = part.callId || `toolu_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 					toolCalls.push({
@@ -61,6 +113,7 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 						name: part.name,
 						input: (part.input as Record<string, unknown>) ?? {},
 					});
+					collectedParts++;
 				} else if (isToolResultPart(part)) {
 					const callId = (part as { callId?: string }).callId ?? "";
 					const content = collectToolResultText(part as { content?: ReadonlyArray<unknown> });
@@ -69,9 +122,11 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 						tool_use_id: callId,
 						content,
 					});
+					collectedParts++;
 				} else if (part instanceof vscode.LanguageModelThinkingPart) {
 					const content = Array.isArray(part.value) ? part.value.join("") : part.value;
 					thinkingParts.push(content);
+					collectedParts++;
 				}
 			}
 
@@ -138,6 +193,18 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 				});
 			}
 
+			// Apply pending cache_control markers to the appropriate block. The block order we built
+			// above does not always map 1:1 to the original part order (text is joined, tool results
+			// migrate, etc.), so we approximate: a marker that arrived after K source parts is attached
+			// to the block at index min(K-1, blocks.length-1). Markers seen before any part go on block 0.
+			for (const { afterPartIndex, cc } of pendingCacheControls) {
+				if (contentBlocks.length === 0) {
+					continue;
+				}
+				const target = Math.min(Math.max(afterPartIndex - 1, 0), contentBlocks.length - 1);
+				contentBlocks[target].cache_control = cc;
+			}
+
 			// Only add message if we have content blocks
 			if (contentBlocks.length > 0) {
 				out.push({
@@ -160,9 +227,21 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			rb.max_tokens = um.max_tokens;
 		}
 
-		// Add system content if we extracted it
+		// Add system content if we extracted it. When caching is enabled, emit the system prompt
+		// as a structured `text` block array carrying a `cache_control` breakpoint — without this,
+		// Anthropic will never cache the (often very long) Copilot system prompt and every turn pays
+		// full input cost. The string form remains the fallback when caching is disabled.
 		if (this._systemContent) {
-			rb.system = this._systemContent;
+			if (this._cacheControlEnabled) {
+				const systemBlock: AnthropicTextBlock = {
+					type: "text",
+					text: this._systemContent,
+					cache_control: { type: "ephemeral" },
+				};
+				rb.system = [systemBlock];
+			} else {
+				rb.system = this._systemContent;
+			}
 		}
 
 		// Add temperature
@@ -189,6 +268,13 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 				description: tool.function.description,
 				input_schema: tool.function.parameters,
 			}));
+			// Mark the last tool with a cache_control breakpoint so the tool-definitions prefix is cached.
+			// Tool definitions are large and stable across a session — this is one of the highest-value
+			// breakpoints to set, and Anthropic counts everything up to and including this tool toward
+			// the cached prefix on subsequent requests.
+			if (this._cacheControlEnabled && rb.tools.length > 0) {
+				rb.tools[rb.tools.length - 1].cache_control = { type: "ephemeral" };
+			}
 		}
 
 		// Add tool_choice

--- a/src/anthropic/anthropicApi.ts
+++ b/src/anthropic/anthropicApi.ts
@@ -300,7 +300,109 @@ export class AnthropicApi extends CommonApi<AnthropicMessage, AnthropicRequestBo
 			}
 		}
 
+		// Anthropic accepts at most 4 `cache_control` breakpoints per request. The host (Copilot)
+		// may emit several breakpoints inside `messages` via its own caching strategy; combined with
+		// the system + last-tool breakpoints we add above, the total can exceed the cap and the API
+		// returns 400. Strip the *earliest* in-message breakpoints first — Anthropic's cache lookup
+		// matches the longest cached prefix, so the most recent (rightmost) breakpoints carry the
+		// most value, and the system / tools breakpoints sit at the very front of the prefix and
+		// rarely change, so they're worth keeping.
+		if (this._cacheControlEnabled) {
+			this.enforceCacheControlBudget(rb);
+		}
+
 		return rb;
+	}
+
+	/**
+	 * Anthropic accepts at most 4 `cache_control` breakpoints per request. This method counts
+	 * every breakpoint currently set on `system`, `tools`, and each message content block, and
+	 * if the total exceeds 4, strips breakpoints in a stable priority order:
+	 *   1. In-message breakpoints, earliest first (least valuable — covers shortest prefix).
+	 *   2. The tools breakpoint, if still over budget after step 1.
+	 *   3. The system breakpoint, last (most valuable — covers longest stable prefix).
+	 */
+	private enforceCacheControlBudget(rb: AnthropicRequestBody): void {
+		const MAX = 4;
+
+		// Tally and locate every breakpoint we might need to strip.
+		let total = 0;
+		const systemBlocksWithCC: AnthropicTextBlock[] = [];
+		const toolsWithCC: { name: string }[] = [];
+		const msgBlocksWithCC: { cache_control?: AnthropicCacheControl }[] = [];
+
+		if (Array.isArray(rb.system)) {
+			for (const block of rb.system) {
+				if (block.cache_control) {
+					systemBlocksWithCC.push(block);
+					total++;
+				}
+			}
+		}
+		if (rb.tools) {
+			for (const tool of rb.tools) {
+				if (tool.cache_control) {
+					toolsWithCC.push(tool);
+					total++;
+				}
+			}
+		}
+		for (const msg of rb.messages) {
+			if (Array.isArray(msg.content)) {
+				for (const block of msg.content) {
+					const b = block as { cache_control?: AnthropicCacheControl };
+					if (b.cache_control) {
+						msgBlocksWithCC.push(b);
+						total++;
+					}
+				}
+			}
+		}
+
+		if (total <= MAX) {
+			return;
+		}
+
+		let toRemove = total - MAX;
+		const removalLog: string[] = [];
+
+		// Step 1: drop earliest in-message breakpoints (push-order == document order here because
+		// we walked messages front-to-back, and each message's blocks front-to-back).
+		for (const block of msgBlocksWithCC) {
+			if (toRemove === 0) {
+				break;
+			}
+			delete block.cache_control;
+			toRemove--;
+			removalLog.push("message");
+		}
+
+		// Step 2: drop tools breakpoint(s) if still over budget.
+		for (const tool of toolsWithCC) {
+			if (toRemove === 0) {
+				break;
+			}
+			delete (tool as { cache_control?: unknown }).cache_control;
+			toRemove--;
+			removalLog.push("tool");
+		}
+
+		// Step 3: as a last resort, drop the system breakpoint(s).
+		for (const block of systemBlocksWithCC) {
+			if (toRemove === 0) {
+				break;
+			}
+			delete block.cache_control;
+			toRemove--;
+			removalLog.push("system");
+		}
+
+		logger.debug("anthropic.cache_control.trim", {
+			modelId: this._modelId,
+			originalCount: total,
+			finalCount: MAX,
+			dropped: removalLog,
+		});
 	}
 
 	/**

--- a/src/anthropic/anthropicTypes.ts
+++ b/src/anthropic/anthropicTypes.ts
@@ -5,9 +5,20 @@
 
 export type AnthropicRole = "user" | "assistant";
 
+/**
+ * Anthropic prompt caching breakpoint.
+ * @see https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+ */
+export interface AnthropicCacheControl {
+	type: "ephemeral";
+	/** Optional cache lifetime — "5m" (default) or "1h". */
+	ttl?: "5m" | "1h";
+}
+
 export interface AnthropicTextBlock {
 	type: "text";
 	text: string;
+	cache_control?: AnthropicCacheControl;
 }
 
 export interface AnthropicImageBlock {
@@ -17,12 +28,14 @@ export interface AnthropicImageBlock {
 		media_type: string;
 		data: string;
 	};
+	cache_control?: AnthropicCacheControl;
 }
 
 export interface AnthropicThinkingBlock {
 	type: "thinking";
 	thinking: string;
 	signature?: string;
+	cache_control?: AnthropicCacheControl;
 }
 
 export interface AnthropicToolUseBlock {
@@ -30,6 +43,7 @@ export interface AnthropicToolUseBlock {
 	id: string;
 	name: string;
 	input: Record<string, unknown>;
+	cache_control?: AnthropicCacheControl;
 }
 
 export interface AnthropicToolResultBlock {
@@ -37,6 +51,7 @@ export interface AnthropicToolResultBlock {
 	tool_use_id: string;
 	content: string | AnthropicTextBlock[];
 	is_error?: boolean;
+	cache_control?: AnthropicCacheControl;
 }
 
 export type AnthropicContentBlock =
@@ -77,6 +92,7 @@ export interface AnthropicToolDefinition {
 	name: string;
 	description?: string;
 	input_schema?: object;
+	cache_control?: AnthropicCacheControl;
 }
 
 export type AnthropicToolChoice =

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -243,7 +243,7 @@ export class HuggingFaceChatModelProvider implements LanguageModelChatProvider {
 				await ollamaApi.processStreamingResponse(response.body, trackingProgress, token);
 			} else if (apiMode === "anthropic") {
 				// Anthropic API mode
-				const anthropicApi = new AnthropicApi(model.id);
+				const anthropicApi = new AnthropicApi(model.id, um?.cache_control !== false);
 				const anthropicMessages = anthropicApi.convertMessages(messages, modelConfig);
 
 				// requestBody

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,20 @@ export interface HFModelItem {
 	 * If not specified, falls back to global `oaicopilot.delay` configuration.
 	 */
 	delay?: number;
+
+	/**
+	 * Enable Anthropic prompt caching breakpoints (only effective when `apiMode` is `"anthropic"`).
+	 *
+	 * When enabled, the provider will:
+	 *   - Convert `system` into a structured array and mark it with `cache_control: { type: "ephemeral" }`.
+	 *   - Mark the last entry of `tools` with `cache_control: { type: "ephemeral" }`.
+	 *   - Honor in-message `cache_control` markers emitted by the host (Copilot) — i.e. a
+	 *     `LanguageModelDataPart` with `mimeType === "cache_control"` is converted to a real
+	 *     Anthropic `cache_control` field on the preceding content block.
+	 *
+	 * Defaults to `true`. Set to `false` for upstream providers that reject `cache_control`.
+	 */
+	cache_control?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Anthropic prompt caching was effectively a no-op in this extension: requests carried no `cache_control` markers anywhere, so `cache_read_input_tokens` always came back as 0 even when usage parsing already supported the field. With Copilot's system prompt and tool definitions being large and stable, every turn was paying full input cost.

This PR wires up real `cache_control` breakpoints for `apiMode: "anthropic"`.

**What changes**

- `system` is promoted from a plain string to `AnthropicTextBlock[]` and the (single) block is tagged with `cache_control: { type: "ephemeral" }`. The string form remains the fallback when caching is disabled.
- The **last** entry of `tools` is tagged with `cache_control: { type: "ephemeral" }` — tool definitions are large and stable across a session, so this is one of the highest-value breakpoints.
- `convertMessages` now recognises `LanguageModelDataPart` parts with `mimeType === "cache_control"` (these were previously silently dropped). The payload is decoded as JSON (`{type:"ephemeral", ttl?:"5m"|"1h"}`, default `{type:"ephemeral"}`) and attached to the appropriate content block of the same message, so any in-message breakpoint Copilot decides to emit is honored.
- New per-model `cache_control?: boolean` config (default `true`), surfaced in the `oaicopilot.models` JSON schema. Set to `false` for upstream providers / proxies that reject the `cache_control` field.

**Why default-on**

The cost-per-token reduction on cache hits is large (~90% on cached input), and Anthropic ignores `cache_control` if the upstream doesn't support it. The only realistic failure mode is a strict third-party proxy rejecting unknown fields — that's what the opt-out is for.

**Non-anthropic routes untouched**

OpenAI, OpenAI-Responses, Ollama, and Gemini paths are not modified. The constructor signature for `AnthropicApi` gains a defaulted parameter, so call sites outside this PR continue to work.

## Test plan

- [x] Configure a Claude model with `apiMode: "anthropic"` and observe `cache_creation_input_tokens` > 0 on the first turn of a chat
- [x] Send a follow-up turn in the same chat → `cache_read_input_tokens` should be > 0 (cache hit on system + tools)
- [x] Set `"cache_control": false` on the model entry → request should contain no `cache_control` fields anywhere; behavior should match pre-PR
- [x] Existing non-anthropic providers (OpenAI / Ollama / Gemini) unaffected

Reported by an extension user who noticed `cache_read_input_tokens` was always 0 in this extension while Claude Code on the same endpoint was caching normally.