### PR TITLE
feat: add Copilot reasoning effort picker support for OpenRouter

### DIFF
--- a/assets/configView/configView.html
+++ b/assets/configView/configView.html
@@ -383,7 +383,7 @@
 									</div>
 									<div class="field">
 										<label for="modelReasoningEffortOR">Reasoning Effort</label>
-										<div class="field-description">Include "reasoning.effort" in request body.</div>
+										<div class="field-description">Default OpenRouter reasoning effort. Leave empty to hide the Copilot picker.</div>
 										<select id="modelReasoningEffortOR" class="model-input">
 											<option value=""></option>
 											<option value="max">Max</option>

--- a/src/modelConfiguration.ts
+++ b/src/modelConfiguration.ts
@@ -62,6 +62,13 @@ export function isReasoningEffortPickerEnabled(
 	return isReasoningEffortValue(model?.reasoning_effort);
 }
 
+export function isOpenRouterReasoningEffortPickerEnabled(
+	model: HFModelItem | undefined
+): boolean {
+	const reasoningConfig = model?.reasoning as { effort?: unknown } | undefined;
+	return isReasoningEffortValue(reasoningConfig?.effort);
+}
+
 export function getConfiguredReasoningEffort(
 	options: vscode.ProvideLanguageModelChatResponseOptions | undefined,
 	fallback: ReasoningEffortPickerValue = "medium"

--- a/src/openai/openaiApi.ts
+++ b/src/openai/openaiApi.ts
@@ -8,7 +8,7 @@ import {
 } from "vscode";
 
 import type { HFModelItem, ReasoningConfig, TokenUsage } from "../types";
-import { getConfiguredReasoningEffort, isReasoningEffortPickerEnabled } from "../modelConfiguration";
+import { getConfiguredReasoningEffort, isReasoningEffortPickerEnabled, isOpenRouterReasoningEffortPickerEnabled, type ReasoningEffortPickerValue } from "../modelConfiguration";
 
 import type {
 	OpenAIChatMessage,
@@ -201,7 +201,12 @@ export class OpenaiApi extends CommonApi<OpenAIChatMessage, Record<string, unkno
 			const reasoningConfig: ReasoningConfig = um.reasoning as ReasoningConfig;
 			if (reasoningConfig.enabled !== false) {
 				const reasoningObj: Record<string, unknown> = {};
-				const effort = reasoningConfig.effort;
+
+				let effort = reasoningConfig.effort;
+				if (isOpenRouterReasoningEffortPickerEnabled(um)) {
+					effort = getConfiguredReasoningEffort(options, effort as ReasoningEffortPickerValue);
+				}
+
 				const maxTokensReasoning = reasoningConfig.max_tokens || 2000; // Default 2000 as per docs
 				if (effort && effort !== "auto") {
 					reasoningObj.effort = effort;

--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -6,6 +6,7 @@ import {
 	createReasoningEffortConfigurationSchema,
 	type ModelPickerChatInformation,
 	isReasoningEffortValue,
+	isOpenRouterReasoningEffortPickerEnabled,
 } from "./modelConfiguration";
 import { normalizeUserModels } from "./utils";
 import { VersionManager } from "./versionManager";
@@ -46,9 +47,15 @@ export async function prepareLanguageModelChatInformation(
 				const modelId = m.configId ? `${m.id}::${m.configId}` : m.id;
 				const modelName = m.displayName || (m.configId ? `${m.id}::${m.configId}` : `${m.id}`);
 				const detail = m.owned_by ? `${m.owned_by} (${EXTENSION_LABEL})` : EXTENSION_LABEL;
-				const reasoningEffort = isReasoningEffortValue(m.reasoning_effort) ? m.reasoning_effort : undefined;
 
-				return {
+				let reasoningEffort: string | undefined;
+				if (isReasoningEffortValue(m.reasoning_effort)) {
+					reasoningEffort = m.reasoning_effort;
+				} else if (isOpenRouterReasoningEffortPickerEnabled(m)) {
+					reasoningEffort = (m.reasoning as { effort?: string })?.effort;
+				}
+
+				const modelInfo: Record<string, unknown> = {
 					id: modelId,
 					name: modelName,
 					detail: detail,
@@ -58,14 +65,17 @@ export async function prepareLanguageModelChatInformation(
 					maxInputTokens: maxInput,
 					maxOutputTokens: maxOutput,
 					isUserSelectable: true,
-					...(reasoningEffort
-						? { configurationSchema: createReasoningEffortConfigurationSchema(reasoningEffort) }
-						: {}),
 					capabilities: {
 						toolCalling: true,
 						imageInput: m?.vision ?? false,
 					},
-				} satisfies ModelPickerChatInformation;
+				};
+
+				if (isReasoningEffortValue(reasoningEffort)) {
+					modelInfo.configurationSchema = createReasoningEffortConfigurationSchema(reasoningEffort as "minimal" | "low" | "medium" | "high" | "xhigh" | "max");
+				}
+
+				return modelInfo as unknown as ModelPickerChatInformation;
 			});
 	} else {
 		// Fallback: Fetch models from API

--- a/src/test/modelConfiguration.test.ts
+++ b/src/test/modelConfiguration.test.ts
@@ -6,6 +6,7 @@ import {
 	createReasoningEffortConfigurationSchema,
 	getConfiguredReasoningEffort,
 	isReasoningEffortPickerEnabled,
+	isOpenRouterReasoningEffortPickerEnabled,
 	type ModelPickerChatInformation,
 	REASONING_EFFORT_CONFIGURATION_SCHEMA,
 } from "../modelConfiguration";
@@ -32,6 +33,14 @@ suite("modelConfiguration", () => {
 		assert.strictEqual(isReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning_effort: "" }), false);
 		assert.strictEqual(isReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning_effort: "custom" }), false);
 		assert.strictEqual(isReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning_effort: "high" }), true);
+	});
+
+	test("only enables the OpenRouter picker when the model has a reasoning effort default", () => {
+		assert.strictEqual(isOpenRouterReasoningEffortPickerEnabled({ id: "m", owned_by: "p" }), false);
+		assert.strictEqual(isOpenRouterReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning: {} }), false);
+		assert.strictEqual(isOpenRouterReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning: { effort: "" } }), false);
+		assert.strictEqual(isOpenRouterReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning: { effort: "custom" } }), false);
+		assert.strictEqual(isOpenRouterReasoningEffortPickerEnabled({ id: "m", owned_by: "p", reasoning: { effort: "high" } }), true);
 	});
 
 	test("defines reasoning effort choices for provider configuration", () => {
@@ -104,6 +113,32 @@ suite("modelConfiguration", () => {
 		}
 	});
 
+	test("registers OpenRouter model with reasoning effort metadata", async () => {
+		const config = vscode.workspace.getConfiguration();
+		const previousModels = config.get<unknown>("oaicopilot.models", []);
+		const cts = new vscode.CancellationTokenSource();
+		const model: HFModelItem = {
+			...deepSeekModel,
+			id: "openrouter-model",
+			displayName: undefined,
+			reasoning_effort: undefined,
+			reasoning: { effort: "low" }
+		};
+
+		try {
+			await config.update("oaicopilot.models", [model], vscode.ConfigurationTarget.Global);
+
+			const infos = await prepareLanguageModelChatInformation({ silent: true }, cts.token, {} as vscode.SecretStorage);
+			const info = infos.find((item) => item.id === "openrouter-model") as ModelPickerChatInformation | undefined;
+
+			assert.ok(info, "openrouter-model should be registered");
+			assert.deepStrictEqual(info.configurationSchema, createReasoningEffortConfigurationSchema("low"));
+		} finally {
+			cts.dispose();
+			await config.update("oaicopilot.models", previousModels, vscode.ConfigurationTarget.Global);
+		}
+	});
+
 	test("applies selected reasoning effort to OpenAI-compatible chat requests", () => {
 		const requestBody = new OpenaiApi("deepseek-v4-pro").prepareRequestBody(
 			{ model: "deepseek-v4-pro", messages: [], stream: true },
@@ -112,6 +147,16 @@ suite("modelConfiguration", () => {
 		);
 
 		assert.strictEqual(requestBody.reasoning_effort, "high");
+	});
+
+	test("applies selected reasoning effort to OpenRouter chat requests", () => {
+		const requestBody = new OpenaiApi("openrouter-model").prepareRequestBody(
+			{ model: "openrouter-model", messages: [], stream: true },
+			{ ...deepSeekModel, reasoning_effort: undefined, reasoning: { effort: "low" } },
+			{ modelConfiguration: { reasoningEffort: "max" } } as never
+		);
+
+		assert.deepStrictEqual(requestBody.reasoning, { effort: "max" });
 	});
 
 	test("falls back to the configured default reasoning effort when Copilot has no temporary override", () => {


### PR DESCRIPTION
## Summary

This PR extends the Copilot `Reasoning Effort` picker support to OpenRouter-compatible models.

Following the implementation in #237 for OpenAI-compatible models, this PR allows users to temporarily override the reasoning effort for a single request when using OpenRouter models.

## Behavior

- If `reasoning.effort` is unset or empty:
  - the model is registered normally;
  - no Copilot reasoning effort picker is shown.

- If `reasoning.effort` is set to a supported value:
  - the model is registered with a Copilot `configurationSchema`;
  - the Copilot chat input shows a `Reasoning Effort` picker;
  - the configured `reasoning.effort` value is used as the picker default.

- If the user changes the picker value in Copilot:
  - that temporary selection is used for the current request.

- If Copilot does not pass a temporary picker value:
  - the configured model-level `reasoning.effort` is used as the fallback.

## Implementation

- Added `isOpenRouterReasoningEffortPickerEnabled` helper in `src/modelConfiguration.ts`.
- Updated `prepareLanguageModelChatInformation` in `src/provideModel.ts` to register the `configurationSchema` for OpenRouter models.
- Updated `OpenaiApi` in `src/openai/openaiApi.ts` to apply the selected reasoning effort to the `reasoning.effort` field in the OpenRouter request body.
- Updated the configuration UI in `assets/configView/configView.html` to clarify that leaving the `Reasoning Effort` field empty hides the Copilot picker.
- Added tests in `src/test/modelConfiguration.test.ts` to verify the new functionality.