### PR TITLE
Namespace internal picker model ids to avoid collisions with built-in Copilot models

### DIFF
--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -7,7 +7,7 @@ import {
 	type ModelPickerChatInformation,
 	isReasoningEffortValue,
 } from "./modelConfiguration";
-import { normalizeUserModels } from "./utils";
+import { buildInternalModelId, normalizeUserModels } from "./utils";
 import { VersionManager } from "./versionManager";
 import { fetchGeminiModels } from "./gemini/geminiApi";
 import { fetchOllamaModels } from "./ollama/ollamaApi";
@@ -42,8 +42,7 @@ export async function prepareLanguageModelChatInformation(
 				const maxOutput = m?.max_completion_tokens ?? m?.max_tokens ?? DEFAULT_MAX_TOKENS;
 				const maxInput = Math.max(1, contextLen - maxOutput);
 
-				// Use configId when present so each model configuration stays distinct.
-				const modelId = m.configId ? `${m.id}::${m.configId}` : m.id;
+				const modelId = buildInternalModelId(m.id, m.configId);
 				const modelName = m.displayName || (m.configId ? `${m.id}::${m.configId}` : `${m.id}`);
 				const detail = m.owned_by ? `${m.owned_by} (${EXTENSION_LABEL})` : EXTENSION_LABEL;
 				const reasoningEffort = isReasoningEffortValue(m.reasoning_effort) ? m.reasoning_effort : undefined;
@@ -100,7 +99,7 @@ export async function prepareLanguageModelChatInformation(
 				const maxInput = Math.max(1, contextLen - maxOutput);
 				const detail = p.provider ? `${p.provider} (${EXTENSION_LABEL})` : EXTENSION_LABEL;
 				entries.push({
-					id: `${m.id}:${p.provider}`,
+					id: buildInternalModelId(`${m.id}:${p.provider}`),
 					name: `${m.id}`,
 					detail: detail,
 					tooltip: detail,
@@ -122,7 +121,7 @@ export async function prepareLanguageModelChatInformation(
 				const maxOutput = DEFAULT_MAX_TOKENS;
 				const maxInput = Math.max(1, contextLen - maxOutput);
 				entries.push({
-					id: `${m.id}`,
+					id: buildInternalModelId(`${m.id}`),
 					name: `${m.id}`,
 					detail: EXTENSION_LABEL,
 					tooltip: EXTENSION_LABEL,

--- a/src/test/modelConfiguration.test.ts
+++ b/src/test/modelConfiguration.test.ts
@@ -14,6 +14,7 @@ import { OpenaiApi } from "../openai/openaiApi";
 import { OpenaiResponsesApi } from "../openai/openaiResponsesApi";
 import { prepareLanguageModelChatInformation } from "../provideModel";
 import type { HFModelItem } from "../types";
+import { buildInternalModelId, parseModelId } from "../utils";
 
 suite("modelConfiguration", () => {
 	const deepSeekModel: HFModelItem = {
@@ -66,7 +67,9 @@ suite("modelConfiguration", () => {
 			await config.update("oaicopilot.models", [model], vscode.ConfigurationTarget.Global);
 
 			const infos = await prepareLanguageModelChatInformation({ silent: true }, cts.token, {} as vscode.SecretStorage);
-			const info = infos.find((item) => item.id === "deepseek-v4-flash") as ModelPickerChatInformation | undefined;
+			const info = infos.find(
+				(item) => item.id === buildInternalModelId("deepseek-v4-flash")
+			) as ModelPickerChatInformation | undefined;
 
 			assert.ok(info, "deepseek-v4-flash should be registered");
 			assert.strictEqual(info.name, "deepseek-v4-flash");
@@ -94,7 +97,9 @@ suite("modelConfiguration", () => {
 			await config.update("oaicopilot.models", [model], vscode.ConfigurationTarget.Global);
 
 			const infos = await prepareLanguageModelChatInformation({ silent: true }, cts.token, {} as vscode.SecretStorage);
-			const info = infos.find((item) => item.id === "deepseek-v4-flash") as ModelPickerChatInformation | undefined;
+			const info = infos.find(
+				(item) => item.id === buildInternalModelId("deepseek-v4-flash")
+			) as ModelPickerChatInformation | undefined;
 
 			assert.ok(info, "deepseek-v4-flash should be registered");
 			assert.strictEqual(info.configurationSchema, undefined);
@@ -102,6 +107,44 @@ suite("modelConfiguration", () => {
 			cts.dispose();
 			await config.update("oaicopilot.models", previousModels, vscode.ConfigurationTarget.Global);
 		}
+	});
+
+	test("uses internal picker ids so built-in Copilot model ids do not collide", async () => {
+		const config = vscode.workspace.getConfiguration();
+		const previousModels = config.get<unknown>("oaicopilot.models", []);
+		const cts = new vscode.CancellationTokenSource();
+		const model: HFModelItem = {
+			id: "gpt-5.4",
+			owned_by: "external-provider",
+			baseUrl: "https://example.com/v1",
+			apiMode: "openai",
+		};
+
+		try {
+			await config.update("oaicopilot.models", [model], vscode.ConfigurationTarget.Global);
+
+			const infos = await prepareLanguageModelChatInformation({ silent: true }, cts.token, {} as vscode.SecretStorage);
+			const info = infos.find((item) => item.name === "gpt-5.4");
+
+			assert.ok(info, "gpt-5.4 should be registered");
+			assert.strictEqual(info?.id, buildInternalModelId("gpt-5.4"));
+			assert.notStrictEqual(info?.id, "gpt-5.4");
+			assert.deepStrictEqual(parseModelId(info?.id ?? ""), { baseId: "gpt-5.4" });
+		} finally {
+			cts.dispose();
+			await config.update("oaicopilot.models", previousModels, vscode.ConfigurationTarget.Global);
+		}
+	});
+
+	test("parses legacy and internal model ids", () => {
+		assert.deepStrictEqual(parseModelId("glm-4.6::thinking"), {
+			baseId: "glm-4.6",
+			configId: "thinking",
+		});
+		assert.deepStrictEqual(parseModelId(buildInternalModelId("gpt-5.4", "external")), {
+			baseId: "gpt-5.4",
+			configId: "external",
+		});
 	});
 
 	test("applies selected reasoning effort to OpenAI-compatible chat requests", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,61 @@ export interface ParsedModelId {
 	configId?: string;
 }
 
+const INTERNAL_MODEL_ID_PREFIX = "__oaicopilot_internal__";
+
+function encodeInternalModelIdPart(value: string): string {
+	return Buffer.from(value, "utf8")
+		.toString("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/u, "");
+}
+
+function decodeInternalModelIdPart(value: string): string {
+	const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+	const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+	return Buffer.from(padded, "base64").toString("utf8");
+}
+
+function tryParseInternalModelId(modelId: string): ParsedModelId | undefined {
+	if (!modelId.startsWith(INTERNAL_MODEL_ID_PREFIX)) {
+		return undefined;
+	}
+
+	const encodedPayload = modelId.slice(INTERNAL_MODEL_ID_PREFIX.length);
+	if (!encodedPayload) {
+		return undefined;
+	}
+
+	const parts = encodedPayload.split("::");
+	const encodedBaseId = parts[0];
+	if (!encodedBaseId) {
+		return undefined;
+	}
+
+	try {
+		const baseId = decodeInternalModelIdPart(encodedBaseId);
+		const encodedConfigId = parts.length >= 2 ? parts.slice(1).join("::") : undefined;
+		const configId = encodedConfigId ? decodeInternalModelIdPart(encodedConfigId) : undefined;
+
+		return {
+			baseId,
+			...(configId ? { configId } : {}),
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+export function buildInternalModelId(baseId: string, configId?: string): string {
+	const encodedBaseId = encodeInternalModelIdPart(baseId);
+	if (configId) {
+		return `${INTERNAL_MODEL_ID_PREFIX}${encodedBaseId}::${encodeInternalModelIdPart(configId)}`;
+	}
+
+	return `${INTERNAL_MODEL_ID_PREFIX}${encodedBaseId}`;
+}
+
 export function getModelProviderId(model: unknown): string {
 	if (!model || typeof model !== "object") {
 		return "";
@@ -65,6 +120,11 @@ export function normalizeUserModels(models: unknown): HFModelItem[] {
  * Format: "baseId::configId" or just "baseId"
  */
 export function parseModelId(modelId: string): ParsedModelId {
+	const parsedInternalModelId = tryParseInternalModelId(modelId);
+	if (parsedInternalModelId) {
+		return parsedInternalModelId;
+	}
+
 	const parts = modelId.split("::");
 	if (parts.length >= 2) {
 		return {


### PR DESCRIPTION
This PR fixes a model-picker collision when an external model id matches a built-in Copilot model id.

For example, if a user configures an external model with id `gpt-5.4`, the model does not appear in the picker because the picker entry collides with the built-in model entry.

Approach:
- Use an internal extension-scoped model id when registering `LanguageModelChatInformation`
- Keep the original provider model id for outgoing API requests
- Preserve existing `configId` behavior
- Add regression tests for duplicate-id scenarios

Validation:
- `npm run compile`
- `npm test -- --grep modelConfiguration`

I am happy to revise the implementation if maintainers prefer a different internal ID scheme.