### PR TITLE
fix: suppress Copilot budget notification

### DIFF
--- a/src/provideModel.ts
+++ b/src/provideModel.ts
@@ -58,6 +58,7 @@ export async function prepareLanguageModelChatInformation(
 					maxInputTokens: maxInput,
 					maxOutputTokens: maxOutput,
 					isUserSelectable: true,
+					isBYOK: true,
 					...(reasoningEffort
 						? { configurationSchema: createReasoningEffortConfigurationSchema(reasoningEffort) }
 						: {}),
@@ -109,6 +110,7 @@ export async function prepareLanguageModelChatInformation(
 					maxInputTokens: maxInput,
 					maxOutputTokens: maxOutput,
 					isUserSelectable: true,
+					isBYOK: true,
 					capabilities: {
 						toolCalling: true,
 						imageInput: vision,
@@ -131,6 +133,7 @@ export async function prepareLanguageModelChatInformation(
 					maxInputTokens: maxInput,
 					maxOutputTokens: maxOutput,
 					isUserSelectable: true,
+					isBYOK: true,
 					capabilities: {
 						toolCalling: true,
 						imageInput: true,

--- a/src/test/modelConfiguration.test.ts
+++ b/src/test/modelConfiguration.test.ts
@@ -72,6 +72,7 @@ suite("modelConfiguration", () => {
 			assert.strictEqual(info.name, "deepseek-v4-flash");
 			assert.strictEqual(info.detail, "deepseek (OAICopilot)");
 			assert.strictEqual(info.isUserSelectable, true);
+			assert.strictEqual(info.isBYOK, true);
 			assert.deepStrictEqual(info.configurationSchema, createReasoningEffortConfigurationSchema("medium"));
 		} finally {
 			cts.dispose();

--- a/src/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode.proposed.chatProvider.d.ts
@@ -51,6 +51,8 @@ declare module "vscode" {
 		readonly category?: { label: string; order: number };
 
 		readonly statusIcon?: ThemeIcon;
+
+		readonly isBYOK?: boolean;
 	}
 
 	export interface LanguageModelChatCapabilities {


### PR DESCRIPTION
## Summary

Add `isBYOK: true` to all `LanguageModelChatInformation` objects returned by the provider, so VS Code no longer shows the Copilot quota notification for models backed by the user's own API key.

为 provider 返回的所有 `LanguageModelChatInformation` 对象添加 `isBYOK: true`，使 VS Code 不再对用户自带 API Key 的模型显示 Copilot 配额通知。

## Problem

VS Code classifies a model as Copilot (subject to quota) unless `metadata.isBYOK === true`. Since this extension didn't set that field, users saw misleading budget notifications ("Credit Limit Reached") even when using their own endpoint.

VS Code 在判断模型是否属于 Copilot 付费配额时，只有 `metadata.isBYOK === true` 才会跳过通知。本扩展此前未设置该字段，导致用户即使使用自己的 API 端点仍会看到误导性的预算提示。

<img width="798" height="310" alt="temp_image_20260616175554" src="https://github.com/user-attachments/assets/d68a09ba-16de-4648-84a7-2a83cb5cae70" />


## Changes

- Add `isBYOK?: boolean` to `LanguageModelChatInformation` in the local proposed API declaration
  在本地 proposed API 类型声明中添加 `isBYOK?: boolean` 字段
- Set `isBYOK: true` in all three model metadata return paths (user-configured models, fetched models with provider, fetched models without provider)
  三处模型元数据返回点均设置 `isBYOK: true`
- Add regression assertion in the existing model configuration test
  在已有的模型配置测试中添加回归断言